### PR TITLE
Remove redundant 'mut' modifier on 'creator' account in 'create' ix

### DIFF
--- a/common/tests/src/dst_program.rs
+++ b/common/tests/src/dst_program.rs
@@ -59,7 +59,7 @@ impl EscrowVariant for DstProgram {
             program_id: cross_chain_escrow_dst::id(),
             accounts: vec![
                 AccountMeta::new(test_state.payer_kp.pubkey(), true),
-                AccountMeta::new(test_state.creator_wallet.keypair.pubkey(), true),
+                AccountMeta::new_readonly(test_state.creator_wallet.keypair.pubkey(), true),
                 AccountMeta::new_readonly(test_state.token, false),
                 AccountMeta::new(test_state.creator_wallet.token_account, false),
                 AccountMeta::new(*escrow, false),

--- a/common/tests/src/src_program.rs
+++ b/common/tests/src/src_program.rs
@@ -59,7 +59,7 @@ impl EscrowVariant for SrcProgram {
             program_id: cross_chain_escrow_src::id(),
             accounts: vec![
                 AccountMeta::new(test_state.payer_kp.pubkey(), true),
-                AccountMeta::new(test_state.creator_wallet.keypair.pubkey(), true),
+                AccountMeta::new_readonly(test_state.creator_wallet.keypair.pubkey(), true),
                 AccountMeta::new_readonly(test_state.token, false),
                 AccountMeta::new(test_state.creator_wallet.token_account, false),
                 AccountMeta::new(*escrow, false),

--- a/programs/cross-chain-escrow-dst/src/lib.rs
+++ b/programs/cross-chain-escrow-dst/src/lib.rs
@@ -167,7 +167,6 @@ pub struct Create<'info> {
     #[account(mut)]
     payer: Signer<'info>,
     /// Puts tokens into escrow
-    #[account(mut)]
     creator: Signer<'info>,
     /// CHECK: check is not necessary as token is only used as a constraint to creator_ata and escrow_ata
     token: Box<Account<'info, Mint>>,

--- a/programs/cross-chain-escrow-src/src/lib.rs
+++ b/programs/cross-chain-escrow-src/src/lib.rs
@@ -182,7 +182,6 @@ pub struct Create<'info> {
     #[account(mut)]
     payer: Signer<'info>,
     /// Puts tokens into escrow
-    #[account(mut)]
     creator: Signer<'info>,
     /// CHECK: check is not necessary as token is only used as a constraint to creator_ata and escrow_ata
     token: Box<Account<'info, Mint>>,

--- a/programs/trading-program/tests/utils/mod.rs
+++ b/programs/trading-program/tests/utils/mod.rs
@@ -163,7 +163,7 @@ pub fn init_escrow_src_tx(
         program_id: trading_program::id(),
         accounts: vec![
             AccountMeta::new(test_state.recipient_wallet.keypair.pubkey(), true), // taker
-            AccountMeta::new(trading_pda, false),                                 // trading_account
+            AccountMeta::new_readonly(trading_pda, false),                        // trading_account
             AccountMeta::new(trading_ata, false), // trading_account_ata
             AccountMeta::new(escrow_pda, false),  // escrow
             AccountMeta::new_readonly(test_state.token, false), // token


### PR DESCRIPTION
**Description:** remove redundant `mut` modifier on `creator` account in `create` instruction of both escrow programs, and fix transaction creation in tests accordingly.