### PR TITLE
Feature: Read dst_amount directly from the raw escrow data

### DIFF
--- a/programs/cross-chain-escrow-src/src/lib.rs
+++ b/programs/cross-chain-escrow-src/src/lib.rs
@@ -501,7 +501,7 @@ pub struct EscrowSrc {
     rescue_start: u32,
     rent_recipient: Pubkey,
     asset_is_native: bool,
-    pub dst_amount: u64,
+    dst_amount: u64,
 }
 
 impl EscrowBase for EscrowSrc {


### PR DESCRIPTION
This PR will remove the `pub` declaration for the `dst_amount` field that was done for testing purposes and get the `dst_amount` in the tests directly from the raw account data instead