### PR TITLE
[SOL-144] Refactor/sol 144 remove escrow base

### DIFF
--- a/common/src/escrow.rs
+++ b/common/src/escrow.rs
@@ -9,83 +9,6 @@ use anchor_spl::token_interface::{
 use crate::error::EscrowError;
 use crate::utils;
 
-pub trait EscrowBase {
-    fn order_hash(&self) -> &[u8; 32];
-
-    fn hashlock(&self) -> &[u8; 32];
-
-    fn creator(&self) -> &Pubkey;
-
-    fn recipient(&self) -> &Pubkey;
-
-    fn token(&self) -> &Pubkey;
-
-    fn amount(&self) -> u64;
-
-    fn safety_deposit(&self) -> u64;
-
-    fn withdrawal_start(&self) -> u32;
-
-    fn public_withdrawal_start(&self) -> u32;
-
-    fn cancellation_start(&self) -> u32;
-
-    fn rescue_start(&self) -> u32;
-
-    fn asset_is_native(&self) -> bool;
-}
-
-pub fn cancel<'info, T>(
-    escrow: &Account<'info, T>,
-    escrow_bump: u8,
-    escrow_ata: &InterfaceAccount<'info, TokenAccount>,
-    creator_ata: Option<&InterfaceAccount<'info, TokenAccount>>,
-    mint: &InterfaceAccount<'info, Mint>,
-    token_program: &Interface<'info, TokenInterface>,
-    rent_recipient: &AccountInfo<'info>,
-    creator: &AccountInfo<'info>,
-    safety_deposit_recipient: &AccountInfo<'info>,
-) -> Result<()>
-where
-    T: EscrowBase + AccountSerialize + AccountDeserialize + Clone,
-{
-    let seeds = [
-        "escrow".as_bytes(),
-        escrow.order_hash(),
-        escrow.hashlock(),
-        escrow.creator().as_ref(),
-        escrow.recipient().as_ref(),
-        escrow.token().as_ref(),
-        &escrow.amount().to_be_bytes(),
-        &escrow.safety_deposit().to_be_bytes(),
-        &escrow.rescue_start().to_be_bytes(),
-        &[escrow_bump],
-    ];
-
-    if escrow.asset_is_native() {
-        close_and_withdraw_native_ata(escrow, escrow_ata, creator, token_program, seeds)?;
-    } else {
-        withdraw_and_close_token_ata(
-            &escrow_ata.to_account_info(),
-            &escrow.to_account_info(),
-            &creator_ata
-                .ok_or(EscrowError::MissingCreatorAta)?
-                .to_account_info(),
-            mint,
-            escrow_ata.amount,
-            token_program,
-            escrow_ata,
-            rent_recipient,
-            &seeds,
-        )?;
-    }
-
-    // Close the escrow account
-    close_escrow_account(escrow, safety_deposit_recipient, rent_recipient)?;
-
-    Ok(())
-}
-
 pub fn rescue_funds<'info>(
     escrow: &AccountInfo<'info>,
     rescue_start: u32,
@@ -202,38 +125,37 @@ pub enum EscrowType {
     Dst,
 }
 
-pub fn close_escrow_account<'info, T>(
-    escrow: &Account<'info, T>,
+pub fn close_escrow_account<'info>(
+    escrow: &AccountInfo<'info>,
+    safety_deposit: u64,
     safety_deposit_recipient: &AccountInfo<'info>,
     rent_recipient: &AccountInfo<'info>,
-) -> Result<()>
-where
-    T: EscrowBase + AccountSerialize + AccountDeserialize + Clone,
-{
+) -> Result<()> {
     // Transfer safety_deposit from escrow to safety_deposit_recipient
     if rent_recipient.key() != safety_deposit_recipient.key() {
-        let safety_deposit = escrow.safety_deposit();
         escrow.sub_lamports(safety_deposit)?;
         safety_deposit_recipient.add_lamports(safety_deposit)?;
     }
 
     // Close escrow account and transfer remaining lamports to rent_recipient
-    escrow.close(rent_recipient.to_account_info())?;
+    let lamports = escrow.lamports();
+    if lamports > 0 {
+        **rent_recipient.lamports.borrow_mut() += lamports;
+        **escrow.lamports.borrow_mut() = 0;
+    }
 
     Ok(())
 }
 
 // Handle native token transfer or WSOL unwrapping and ata closure
-pub fn close_and_withdraw_native_ata<'info, T>(
-    escrow: &Account<'info, T>,
+pub fn close_and_withdraw_native_ata<'info>(
+    escrow: &AccountInfo<'info>,
+    escrow_amount: u64,
     escrow_ata: &InterfaceAccount<'info, TokenAccount>,
     recipient: &AccountInfo<'info>,
     token_program: &Interface<'info, TokenInterface>,
     seeds: [&[u8]; 10],
-) -> Result<()>
-where
-    T: EscrowBase + AccountSerialize + AccountDeserialize + Clone,
-{
+) -> Result<()> {
     // Using escrow pda as an intermediate account to transfer native tokens
     // the leftover lamports from ata's rent will be transferred to the rent recipient
     // after closing the escrow account
@@ -248,8 +170,8 @@ where
     ))?;
 
     // Transfer the native tokens from escrow pda to recipient
-    escrow.sub_lamports(escrow.amount())?;
-    recipient.add_lamports(escrow.amount())?;
+    escrow.sub_lamports(escrow_amount)?;
+    recipient.add_lamports(escrow_amount)?;
 
     Ok(())
 }

--- a/programs/cross-chain-escrow-dst/src/lib.rs
+++ b/programs/cross-chain-escrow-dst/src/lib.rs
@@ -4,8 +4,7 @@ use anchor_spl::token::spl_token::native_mint::ID as NATIVE_MINT;
 use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
 pub use common::constants;
 use common::error::EscrowError;
-use common::escrow::{uni_transfer, EscrowBase, UniTransferParams};
-
+use common::escrow::{uni_transfer, UniTransferParams};
 mod utils;
 
 declare_id!("B9SnVJbXNd6RFNxHqPkTvdr46YPT17xunemTQfDsCNzR");
@@ -177,7 +176,7 @@ pub mod cross_chain_escrow_dst {
             EscrowError::InvalidTime
         );
 
-        common::escrow::cancel(
+        utils::cancel(
             &ctx.accounts.escrow,
             ctx.bumps.escrow,
             &ctx.accounts.escrow_ata,
@@ -477,66 +476,16 @@ pub struct RescueFunds<'info> {
 #[account]
 #[derive(InitSpace)]
 pub struct EscrowDst {
-    order_hash: [u8; 32],
-    hashlock: [u8; 32],
-    creator: Pubkey,
-    recipient: Pubkey,
-    token: Pubkey,
-    asset_is_native: bool,
-    amount: u64,
-    safety_deposit: u64,
-    withdrawal_start: u32,
-    public_withdrawal_start: u32,
-    cancellation_start: u32,
-    rescue_start: u32,
-}
-
-impl EscrowBase for EscrowDst {
-    fn order_hash(&self) -> &[u8; 32] {
-        &self.order_hash
-    }
-
-    fn hashlock(&self) -> &[u8; 32] {
-        &self.hashlock
-    }
-
-    fn creator(&self) -> &Pubkey {
-        &self.creator
-    }
-
-    fn recipient(&self) -> &Pubkey {
-        &self.recipient
-    }
-
-    fn token(&self) -> &Pubkey {
-        &self.token
-    }
-
-    fn amount(&self) -> u64 {
-        self.amount
-    }
-
-    fn safety_deposit(&self) -> u64 {
-        self.safety_deposit
-    }
-
-    fn withdrawal_start(&self) -> u32 {
-        self.withdrawal_start
-    }
-
-    fn public_withdrawal_start(&self) -> u32 {
-        self.public_withdrawal_start
-    }
-
-    fn cancellation_start(&self) -> u32 {
-        self.cancellation_start
-    }
-
-    fn rescue_start(&self) -> u32 {
-        self.rescue_start
-    }
-
-    fn asset_is_native(&self) -> bool {
-        self.asset_is_native
-    }
+    pub order_hash: [u8; 32],
+    pub hashlock: [u8; 32],
+    pub creator: Pubkey,
+    pub recipient: Pubkey,
+    pub token: Pubkey,
+    pub asset_is_native: bool,
+    pub amount: u64,
+    pub safety_deposit: u64,
+    pub withdrawal_start: u32,
+    pub public_withdrawal_start: u32,
+    pub cancellation_start: u32,
+    pub rescue_start: u32,
 }

--- a/programs/cross-chain-escrow-dst/src/utils.rs
+++ b/programs/cross-chain-escrow-dst/src/utils.rs
@@ -1,10 +1,14 @@
 use anchor_lang::{prelude::*, solana_program::keccak::hash};
 use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
-use common::error::EscrowError;
-use common::escrow::EscrowBase;
+use common::{
+    error::EscrowError,
+    escrow::{close_and_withdraw_native_ata, close_escrow_account, withdraw_and_close_token_ata},
+};
 
-pub fn withdraw<'info, T>(
-    escrow: &Account<'info, T>,
+use crate::EscrowDst;
+
+pub fn withdraw<'info>(
+    escrow: &Account<'info, EscrowDst>,
     escrow_bump: u8,
     escrow_ata: &InterfaceAccount<'info, TokenAccount>,
     recipient: &AccountInfo<'info>,
@@ -14,32 +18,30 @@ pub fn withdraw<'info, T>(
     rent_recipient: &AccountInfo<'info>,
     safety_deposit_recipient: &AccountInfo<'info>,
     secret: [u8; 32],
-) -> Result<()>
-where
-    T: EscrowBase + AccountSerialize + AccountDeserialize + Clone,
-{
+) -> Result<()> {
     // Verify that the secret matches the hashlock
     require!(
-        hash(&secret).to_bytes() == *escrow.hashlock(),
+        hash(&secret).to_bytes() == escrow.hashlock,
         EscrowError::InvalidSecret
     );
 
     let seeds = [
         "escrow".as_bytes(),
-        escrow.order_hash(),
-        escrow.hashlock(),
-        escrow.creator().as_ref(),
-        escrow.recipient().as_ref(),
-        escrow.token().as_ref(),
-        &escrow.amount().to_be_bytes(),
-        &escrow.safety_deposit().to_be_bytes(),
-        &escrow.rescue_start().to_be_bytes(),
+        &escrow.order_hash,
+        &escrow.hashlock,
+        escrow.creator.as_ref(),
+        escrow.recipient.as_ref(),
+        escrow.token.as_ref(),
+        &escrow.amount.to_be_bytes(),
+        &escrow.safety_deposit.to_be_bytes(),
+        &escrow.rescue_start.to_be_bytes(),
         &[escrow_bump],
     ];
 
-    if escrow.asset_is_native() {
+    if escrow.asset_is_native {
         common::escrow::close_and_withdraw_native_ata(
-            escrow,
+            &escrow.to_account_info(),
+            escrow.amount,
             escrow_ata,
             recipient,
             token_program,
@@ -62,7 +64,72 @@ where
     }
 
     // Close the escrow account
-    common::escrow::close_escrow_account(escrow, safety_deposit_recipient, rent_recipient)?;
+    common::escrow::close_escrow_account(
+        &escrow.to_account_info(),
+        escrow.safety_deposit,
+        safety_deposit_recipient,
+        rent_recipient,
+    )?;
+
+    Ok(())
+}
+
+pub fn cancel<'info>(
+    escrow: &Account<'info, EscrowDst>,
+    escrow_bump: u8,
+    escrow_ata: &InterfaceAccount<'info, TokenAccount>,
+    creator_ata: Option<&InterfaceAccount<'info, TokenAccount>>,
+    mint: &InterfaceAccount<'info, Mint>,
+    token_program: &Interface<'info, TokenInterface>,
+    rent_recipient: &AccountInfo<'info>,
+    creator: &AccountInfo<'info>,
+    safety_deposit_recipient: &AccountInfo<'info>,
+) -> Result<()> {
+    let seeds = [
+        "escrow".as_bytes(),
+        &escrow.order_hash,
+        &escrow.hashlock,
+        escrow.creator.as_ref(),
+        escrow.recipient.as_ref(),
+        escrow.token.as_ref(),
+        &escrow.amount.to_be_bytes(),
+        &escrow.safety_deposit.to_be_bytes(),
+        &escrow.rescue_start.to_be_bytes(),
+        &[escrow_bump],
+    ];
+
+    if escrow.asset_is_native {
+        close_and_withdraw_native_ata(
+            &escrow.to_account_info(),
+            escrow.amount,
+            escrow_ata,
+            creator,
+            token_program,
+            seeds,
+        )?;
+    } else {
+        withdraw_and_close_token_ata(
+            &escrow_ata.to_account_info(),
+            &escrow.to_account_info(),
+            &creator_ata
+                .ok_or(EscrowError::MissingCreatorAta)?
+                .to_account_info(),
+            mint,
+            escrow_ata.amount,
+            token_program,
+            escrow_ata,
+            rent_recipient,
+            &seeds,
+        )?;
+    }
+
+    // Close the escrow account
+    close_escrow_account(
+        &escrow.to_account_info(),
+        escrow.safety_deposit,
+        safety_deposit_recipient,
+        rent_recipient,
+    )?;
 
     Ok(())
 }

--- a/programs/cross-chain-escrow-src/src/lib.rs
+++ b/programs/cross-chain-escrow-src/src/lib.rs
@@ -8,7 +8,7 @@ use anchor_spl::token_interface::{
 pub use auction::{calculate_premium, calculate_rate_bump, AuctionData};
 pub use common::constants;
 use common::error::EscrowError;
-use common::escrow::{uni_transfer, EscrowBase, UniTransferParams};
+use common::escrow::{uni_transfer, UniTransferParams};
 use primitive_types::U256;
 
 use crate::merkle_tree::MerkleProof;
@@ -289,8 +289,8 @@ pub mod cross_chain_escrow_src {
         let now = common::utils::get_current_timestamp()?;
 
         require!(
-            now >= ctx.accounts.escrow.withdrawal_start()
-                && now < ctx.accounts.escrow.cancellation_start(),
+            now >= ctx.accounts.escrow.withdrawal_start
+                && now < ctx.accounts.escrow.cancellation_start,
             EscrowError::InvalidTime
         );
 
@@ -314,8 +314,8 @@ pub mod cross_chain_escrow_src {
         let now = common::utils::get_current_timestamp()?;
 
         require!(
-            now >= ctx.accounts.escrow.public_withdrawal_start()
-                && now < ctx.accounts.escrow.cancellation_start(),
+            now >= ctx.accounts.escrow.public_withdrawal_start
+                && now < ctx.accounts.escrow.cancellation_start,
             EscrowError::InvalidTime
         );
 
@@ -339,7 +339,7 @@ pub mod cross_chain_escrow_src {
         let now = common::utils::get_current_timestamp()?;
 
         require!(
-            now >= ctx.accounts.escrow.cancellation_start(),
+            now >= ctx.accounts.escrow.cancellation_start,
             EscrowError::InvalidTime
         );
 
@@ -347,7 +347,7 @@ pub mod cross_chain_escrow_src {
         // because they initially covered the entire rent during escrow creation, while the maker
         // receives their tokens back to their initial ATA or wallet if the token is native.
 
-        common::escrow::cancel(
+        utils::cancel(
             &ctx.accounts.escrow,
             ctx.bumps.escrow,
             &ctx.accounts.escrow_ata,
@@ -372,7 +372,7 @@ pub mod cross_chain_escrow_src {
         // which is awarded to the payer who executed the public cancellation, while the maker
         // receives their tokens back to their initial ATA or wallet if the token is native.
 
-        common::escrow::cancel(
+        utils::cancel(
             &ctx.accounts.escrow,
             ctx.bumps.escrow,
             &ctx.accounts.escrow_ata,
@@ -1152,75 +1152,6 @@ pub struct Order {
     allow_multiple_fills: bool,
 }
 
-#[account]
-#[derive(InitSpace)]
-pub struct EscrowSrc {
-    order_hash: [u8; 32],
-    hashlock: [u8; 32],
-    maker: Pubkey,
-    taker: Pubkey,
-    token: Pubkey,
-    amount: u64,
-    safety_deposit: u64,
-    withdrawal_start: u32,
-    public_withdrawal_start: u32,
-    cancellation_start: u32,
-    public_cancellation_start: u32,
-    rescue_start: u32,
-    asset_is_native: bool,
-    dst_amount: [u64; 4],
-}
-
-impl EscrowBase for EscrowSrc {
-    fn order_hash(&self) -> &[u8; 32] {
-        &self.order_hash
-    }
-
-    fn hashlock(&self) -> &[u8; 32] {
-        &self.hashlock
-    }
-
-    fn creator(&self) -> &Pubkey {
-        &self.maker
-    }
-
-    fn recipient(&self) -> &Pubkey {
-        &self.taker
-    }
-
-    fn token(&self) -> &Pubkey {
-        &self.token
-    }
-
-    fn amount(&self) -> u64 {
-        self.amount
-    }
-
-    fn safety_deposit(&self) -> u64 {
-        self.safety_deposit
-    }
-
-    fn withdrawal_start(&self) -> u32 {
-        self.withdrawal_start
-    }
-
-    fn public_withdrawal_start(&self) -> u32 {
-        self.public_withdrawal_start
-    }
-
-    fn cancellation_start(&self) -> u32 {
-        self.cancellation_start
-    }
-
-    fn rescue_start(&self) -> u32 {
-        self.rescue_start
-    }
-
-    fn asset_is_native(&self) -> bool {
-        self.asset_is_native
-    }
-}
-
 fn get_dst_amount(dst_amount: [u64; 4], data: &AuctionData) -> Result<[u64; 4]> {
     let rate_bump = calculate_rate_bump(Clock::get()?.unix_timestamp as u64, data);
     let multiplier = constants::BASE_1E5 + rate_bump;
@@ -1277,4 +1208,23 @@ pub struct DstChainParams {
     pub maker_address: [u8; 32],
     pub token: [u8; 32],
     pub safety_deposit: u128,
+}
+
+#[account]
+#[derive(InitSpace)]
+pub struct EscrowSrc {
+    pub order_hash: [u8; 32],
+    pub hashlock: [u8; 32],
+    pub maker: Pubkey,
+    pub taker: Pubkey,
+    pub token: Pubkey,
+    pub amount: u64,
+    pub safety_deposit: u64,
+    pub withdrawal_start: u32,
+    pub public_withdrawal_start: u32,
+    pub cancellation_start: u32,
+    pub public_cancellation_start: u32,
+    pub rescue_start: u32,
+    pub asset_is_native: bool,
+    pub dst_amount: [u64; 4],
 }

--- a/programs/cross-chain-escrow-src/src/utils.rs
+++ b/programs/cross-chain-escrow-src/src/utils.rs
@@ -1,10 +1,14 @@
 use anchor_lang::{prelude::*, solana_program::keccak::hash};
 use anchor_spl::token_interface::{Mint, TokenAccount, TokenInterface};
-use common::error::EscrowError;
-use common::escrow::EscrowBase;
+use common::{
+    error::EscrowError,
+    escrow::{close_and_withdraw_native_ata, close_escrow_account, withdraw_and_close_token_ata},
+};
 
-pub fn withdraw<'info, T>(
-    escrow: &Account<'info, T>,
+use crate::EscrowSrc;
+
+pub fn withdraw<'info>(
+    escrow: &Account<'info, EscrowSrc>,
     escrow_bump: u8,
     escrow_ata: &InterfaceAccount<'info, TokenAccount>,
     taker_ata: &InterfaceAccount<'info, TokenAccount>,
@@ -13,26 +17,23 @@ pub fn withdraw<'info, T>(
     rent_recipient: &AccountInfo<'info>,
     safety_deposit_recipient: &AccountInfo<'info>,
     secret: [u8; 32],
-) -> Result<()>
-where
-    T: EscrowBase + AccountSerialize + AccountDeserialize + Clone,
-{
+) -> Result<()> {
     // Verify that the secret matches the hashlock
     require!(
-        hash(&secret).to_bytes() == *escrow.hashlock(),
+        hash(&secret).to_bytes() == escrow.hashlock,
         EscrowError::InvalidSecret
     );
 
     let seeds = [
         "escrow".as_bytes(),
-        escrow.order_hash(),
-        escrow.hashlock(),
-        escrow.creator().as_ref(),
-        escrow.recipient().as_ref(),
-        escrow.token().as_ref(),
-        &escrow.amount().to_be_bytes(),
-        &escrow.safety_deposit().to_be_bytes(),
-        &escrow.rescue_start().to_be_bytes(),
+        &escrow.order_hash,
+        &escrow.hashlock,
+        escrow.maker.as_ref(),
+        escrow.taker.as_ref(),
+        escrow.token.as_ref(),
+        &escrow.amount.to_be_bytes(),
+        &escrow.safety_deposit.to_be_bytes(),
+        &escrow.rescue_start.to_be_bytes(),
         &[escrow_bump],
     ];
 
@@ -49,7 +50,72 @@ where
     )?;
 
     // Close the escrow account
-    common::escrow::close_escrow_account(escrow, safety_deposit_recipient, rent_recipient)?;
+    common::escrow::close_escrow_account(
+        &escrow.to_account_info(),
+        escrow.safety_deposit,
+        safety_deposit_recipient,
+        rent_recipient,
+    )?;
+
+    Ok(())
+}
+
+pub fn cancel<'info>(
+    escrow: &Account<'info, EscrowSrc>,
+    escrow_bump: u8,
+    escrow_ata: &InterfaceAccount<'info, TokenAccount>,
+    creator_ata: Option<&InterfaceAccount<'info, TokenAccount>>,
+    mint: &InterfaceAccount<'info, Mint>,
+    token_program: &Interface<'info, TokenInterface>,
+    rent_recipient: &AccountInfo<'info>,
+    creator: &AccountInfo<'info>,
+    safety_deposit_recipient: &AccountInfo<'info>,
+) -> Result<()> {
+    let seeds = [
+        "escrow".as_bytes(),
+        &escrow.order_hash,
+        &escrow.hashlock,
+        escrow.maker.as_ref(),
+        escrow.taker.as_ref(),
+        escrow.token.as_ref(),
+        &escrow.amount.to_be_bytes(),
+        &escrow.safety_deposit.to_be_bytes(),
+        &escrow.rescue_start.to_be_bytes(),
+        &[escrow_bump],
+    ];
+
+    if escrow.asset_is_native {
+        close_and_withdraw_native_ata(
+            &escrow.to_account_info(),
+            escrow.amount,
+            escrow_ata,
+            creator,
+            token_program,
+            seeds,
+        )?;
+    } else {
+        withdraw_and_close_token_ata(
+            &escrow_ata.to_account_info(),
+            &escrow.to_account_info(),
+            &creator_ata
+                .ok_or(EscrowError::MissingCreatorAta)?
+                .to_account_info(),
+            mint,
+            escrow_ata.amount,
+            token_program,
+            escrow_ata,
+            rent_recipient,
+            &seeds,
+        )?;
+    }
+
+    // Close the escrow account
+    close_escrow_account(
+        &escrow.to_account_info(),
+        escrow.safety_deposit,
+        safety_deposit_recipient,
+        rent_recipient,
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
- The `EscrowBase trait` was removed; instead, the fields of the `EscrowSrc` and `EscrowDst` structs were made public.
- The `cancel` function was split into two versions and moved into the `utils` files, since the `EscrowSrc` and `EscrowDst` structs use slightly different fields for seeds (`creator`/`maker`, `recipient`/`taker`).
- The helper functions `close_escrow_account` and `close_and_withdraw_native_ata` were given an additional parameter to eliminate the dependency on the escrow type.