### PR TITLE
[SOL-169] Use the stored bump in deregister

### DIFF
--- a/programs/whitelist/src/lib.rs
+++ b/programs/whitelist/src/lib.rs
@@ -101,7 +101,7 @@ pub struct Deregister<'info> {
         mut,
         close = authority,
         seeds = [RESOLVER_ACCESS_SEED, user.key().as_ref()],
-        bump,
+        bump = resolver_access.bump,
     )]
     pub resolver_access: Account<'info, ResolverAccess>,
 


### PR DESCRIPTION
Problem: In the deregister endpoint, the bump is configured to be re-computed for validating the PDA, but this is unnecessary as bump is already stored in the `resolver_access` account.

Solution: Explicitly use the expected bump as shown [here in this example](https://github.com/solana-developers/anchor-examples/blob/main/account-constraints/seed-bump/programs/example/src/lib.rs#L45) 