### PR TITLE
[SOL-160] Enable/Add/Validate some tests

### DIFF
--- a/programs/cross-chain-escrow-dst/tests/test_cross_chain_escrow_dst_native.rs
+++ b/programs/cross-chain-escrow-dst/tests/test_cross_chain_escrow_dst_native.rs
@@ -1,10 +1,8 @@
-use anchor_lang::error::ErrorCode;
 use anchor_spl::token::spl_token::native_mint::ID as NATIVE_MINT;
 use common::{error::EscrowError, timelocks::Stage};
 use common_tests::dst_program::DstProgram;
 use common_tests::helpers::*;
 use common_tests::tests as common_escrow_tests;
-use common_tests::whitelist::deregister;
 use common_tests::whitelist::prepare_resolvers;
 use solana_program::program_error::ProgramError;
 use solana_program_test::tokio;
@@ -261,47 +259,6 @@ mod test_escrow_native {
             .await
             .unwrap()
             .is_none());
-    }
-
-    #[test_context(TestState)]
-    #[tokio::test]
-    async fn test_public_withdraw_fail_with_unwhitelisted_resolver(test_state: &mut TestState) {
-        test_state.token = NATIVE_MINT;
-        test_state.test_arguments.asset_is_native = true;
-        let withdrawer = Keypair::new();
-        prepare_resolvers(test_state, &[withdrawer.pubkey()]).await;
-        let payer_kp = &test_state.payer_kp;
-        let context = &mut test_state.context;
-
-        transfer_lamports(
-            context,
-            WALLET_DEFAULT_LAMPORTS,
-            payer_kp,
-            &withdrawer.pubkey(),
-        )
-        .await;
-        let (escrow, escrow_ata) = create_escrow(test_state).await;
-
-        deregister(test_state, withdrawer.pubkey()).await;
-        let transaction =
-            DstProgram::get_public_withdraw_tx(test_state, &escrow, &escrow_ata, &withdrawer);
-
-        set_time(
-            &mut test_state.context,
-            test_state
-                .test_arguments
-                .dst_timelocks
-                .get(Stage::DstPublicWithdrawal)
-                .unwrap(),
-        );
-
-        test_state
-            .client
-            .process_transaction(transaction)
-            .await
-            .expect_error(ProgramError::Custom(
-                ErrorCode::AccountNotInitialized.into(),
-            ));
     }
 
     #[test_context(TestState)]

--- a/programs/cross-chain-escrow-dst/tests/test_cross_chain_escrow_dst_native.rs
+++ b/programs/cross-chain-escrow-dst/tests/test_cross_chain_escrow_dst_native.rs
@@ -271,7 +271,6 @@ mod test_escrow_native {
         let withdrawer = Keypair::new();
         prepare_resolvers(test_state, &[withdrawer.pubkey()]).await;
         let payer_kp = &test_state.payer_kp;
-        {
             let context = &mut test_state.context;
 
             transfer_lamports(
@@ -281,7 +280,6 @@ mod test_escrow_native {
                 &withdrawer.pubkey(),
             )
             .await;
-        }
         let (escrow, escrow_ata) = create_escrow(test_state).await;
 
         deregister(test_state, withdrawer.pubkey()).await;

--- a/programs/cross-chain-escrow-dst/tests/test_cross_chain_escrow_dst_native.rs
+++ b/programs/cross-chain-escrow-dst/tests/test_cross_chain_escrow_dst_native.rs
@@ -1,8 +1,10 @@
+use anchor_lang::error::ErrorCode;
 use anchor_spl::token::spl_token::native_mint::ID as NATIVE_MINT;
 use common::{error::EscrowError, timelocks::Stage};
 use common_tests::dst_program::DstProgram;
 use common_tests::helpers::*;
 use common_tests::tests as common_escrow_tests;
+use common_tests::whitelist::deregister;
 use common_tests::whitelist::prepare_resolvers;
 use solana_program::program_error::ProgramError;
 use solana_program_test::tokio;
@@ -259,6 +261,49 @@ mod test_escrow_native {
             .await
             .unwrap()
             .is_none());
+    }
+
+    #[test_context(TestState)]
+    #[tokio::test]
+    async fn test_public_withdraw_fail_with_unwhitelisted_resolver(test_state: &mut TestState) {
+        test_state.token = NATIVE_MINT;
+        test_state.test_arguments.asset_is_native = true;
+        let withdrawer = Keypair::new();
+        prepare_resolvers(test_state, &[withdrawer.pubkey()]).await;
+        let payer_kp = &test_state.payer_kp;
+        {
+            let context = &mut test_state.context;
+
+            transfer_lamports(
+                context,
+                WALLET_DEFAULT_LAMPORTS,
+                payer_kp,
+                &withdrawer.pubkey(),
+            )
+            .await;
+        }
+        let (escrow, escrow_ata) = create_escrow(test_state).await;
+
+        deregister(test_state, withdrawer.pubkey()).await;
+        let transaction =
+            DstProgram::get_public_withdraw_tx(test_state, &escrow, &escrow_ata, &withdrawer);
+
+        set_time(
+            &mut test_state.context,
+            test_state
+                .test_arguments
+                .dst_timelocks
+                .get(Stage::DstPublicWithdrawal)
+                .unwrap(),
+        );
+
+        test_state
+            .client
+            .process_transaction(transaction)
+            .await
+            .expect_error(ProgramError::Custom(
+                ErrorCode::AccountNotInitialized.into(),
+            ));
     }
 
     #[test_context(TestState)]

--- a/programs/cross-chain-escrow-dst/tests/test_cross_chain_escrow_dst_native.rs
+++ b/programs/cross-chain-escrow-dst/tests/test_cross_chain_escrow_dst_native.rs
@@ -271,15 +271,15 @@ mod test_escrow_native {
         let withdrawer = Keypair::new();
         prepare_resolvers(test_state, &[withdrawer.pubkey()]).await;
         let payer_kp = &test_state.payer_kp;
-            let context = &mut test_state.context;
+        let context = &mut test_state.context;
 
-            transfer_lamports(
-                context,
-                WALLET_DEFAULT_LAMPORTS,
-                payer_kp,
-                &withdrawer.pubkey(),
-            )
-            .await;
+        transfer_lamports(
+            context,
+            WALLET_DEFAULT_LAMPORTS,
+            payer_kp,
+            &withdrawer.pubkey(),
+        )
+        .await;
         let (escrow, escrow_ata) = create_escrow(test_state).await;
 
         deregister(test_state, withdrawer.pubkey()).await;

--- a/programs/cross-chain-escrow-src/tests/test_cross_chain_escrow_src_native.rs
+++ b/programs/cross-chain-escrow-src/tests/test_cross_chain_escrow_src_native.rs
@@ -1,4 +1,4 @@
-use anchor_lang::{error::ErrorCode, prelude::ProgramError};
+use anchor_lang::prelude::ProgramError;
 use anchor_spl::token::spl_token::native_mint::ID as NATIVE_MINT;
 use anchor_spl::token::spl_token::state::Account as SplTokenAccount;
 use common::{error::EscrowError, timelocks::Stage};
@@ -72,23 +72,6 @@ mod test_native_src {
                 .await
                 .unwrap()
         );
-    }
-
-    #[test_context(TestState)]
-    #[tokio::test]
-    async fn test_escrow_creation_fails_with_unwhitelisted_resolver(test_state: &mut TestState) {
-        test_state.token = NATIVE_MINT;
-        test_state.test_arguments.asset_is_native = true;
-        create_order(test_state).await;
-        let (_, _, tx) = create_escrow_data(test_state);
-
-        test_state
-            .client
-            .process_transaction(tx)
-            .await
-            .expect_error(ProgramError::Custom(
-                ErrorCode::AccountNotInitialized.into(),
-            ));
     }
 
     #[test_context(TestState)]


### PR DESCRIPTION
Changes:

* Replace commented out test `test_cannot_rescue_funds_by_non_recipient` with `test_cannot_rescue_funds_by_non_creator` as required by the comment.
* Remove commented out test `test_cannot_rescue_funds_by_non_whitelisted_resolver` as it appeared that the logic does not exist in dst contract code.
* For the entrypoints that check white-listing, add tests that check that non-whitelisted actors are forbidden.

