### PR TITLE
[SOL-215] Generalize whitelist program

### DIFF
--- a/common/tests/src/dst_program.rs
+++ b/common/tests/src/dst_program.rs
@@ -41,7 +41,7 @@ impl<S: TokenVariant> EscrowVariant<S> for DstProgram {
 
         let (_, taker_ata) = find_user_ata(test_state);
         let (whitelist_access, _) =
-            get_whitelist_access_address(&cross_chain_escrow_dst::ID_CONST, &withdrawer.pubkey());
+            get_whitelist_access_address(&cross_chain_escrow_dst::ID, &withdrawer.pubkey());
 
         let instruction: Instruction = Instruction {
             program_id: cross_chain_escrow_dst::id(),

--- a/common/tests/src/dst_program.rs
+++ b/common/tests/src/dst_program.rs
@@ -40,7 +40,8 @@ impl<S: TokenVariant> EscrowVariant<S> for DstProgram {
             });
 
         let (_, taker_ata) = find_user_ata(test_state);
-        let (whitelist_access, _) = get_whitelist_access_address(&withdrawer.pubkey());
+        let (whitelist_access, _) =
+            get_whitelist_access_address(&cross_chain_escrow_dst::ID_CONST, &withdrawer.pubkey());
 
         let instruction: Instruction = Instruction {
             program_id: cross_chain_escrow_dst::id(),

--- a/common/tests/src/src_program.rs
+++ b/common/tests/src/src_program.rs
@@ -76,7 +76,7 @@ impl<S: TokenVariant> EscrowVariant<S> for SrcProgram {
 
         let (_, taker_ata) = find_user_ata(test_state);
         let (whitelist_access, _) =
-            get_whitelist_access_address(&cross_chain_escrow_src::ID_CONST, &withdrawer.pubkey());
+            get_whitelist_access_address(&cross_chain_escrow_src::ID, &withdrawer.pubkey());
 
         let instruction: Instruction = Instruction {
             program_id: cross_chain_escrow_src::id(),
@@ -151,7 +151,7 @@ impl<S: TokenVariant> EscrowVariant<S> for SrcProgram {
 
         let (order, order_ata) = get_order_addresses(test_state);
         let (whitelist_access, _) = get_whitelist_access_address(
-            &cross_chain_escrow_src::ID_CONST,
+            &cross_chain_escrow_src::ID,
             &test_state.taker_wallet.keypair.pubkey(),
         );
 
@@ -236,7 +236,7 @@ pub fn create_public_escrow_cancel_tx<S: TokenVariant>(
 
     let (maker_ata, _) = find_user_ata(test_state);
     let (whitelist_access, _) =
-        get_whitelist_access_address(&cross_chain_escrow_src::ID_CONST, &canceller.pubkey());
+        get_whitelist_access_address(&cross_chain_escrow_src::ID, &canceller.pubkey());
 
     let instruction: Instruction = Instruction {
         program_id: cross_chain_escrow_src::id(),
@@ -295,7 +295,7 @@ pub fn get_rescue_funds_from_order_tx<S: TokenVariant>(
         });
 
     let (whitelist_access, _) = get_whitelist_access_address(
-        &cross_chain_escrow_src::ID_CONST,
+        &cross_chain_escrow_src::ID,
         &test_state.taker_wallet.keypair.pubkey(),
     );
 
@@ -499,7 +499,7 @@ pub fn get_cancel_order_by_resolver_tx<T: EscrowVariant<S>, S: TokenVariant>(
         &cross_chain_escrow_src::instruction::CancelOrderByResolver { reward_limit },
     );
     let (whitelist_access, _) = get_whitelist_access_address(
-        &cross_chain_escrow_src::ID_CONST,
+        &cross_chain_escrow_src::ID,
         &test_state.taker_wallet.keypair.pubkey(),
     );
 

--- a/common/tests/src/src_program.rs
+++ b/common/tests/src/src_program.rs
@@ -75,7 +75,8 @@ impl<S: TokenVariant> EscrowVariant<S> for SrcProgram {
             });
 
         let (_, taker_ata) = find_user_ata(test_state);
-        let (whitelist_access, _) = get_whitelist_access_address(&withdrawer.pubkey());
+        let (whitelist_access, _) =
+            get_whitelist_access_address(&cross_chain_escrow_src::ID_CONST, &withdrawer.pubkey());
 
         let instruction: Instruction = Instruction {
             program_id: cross_chain_escrow_src::id(),
@@ -149,8 +150,10 @@ impl<S: TokenVariant> EscrowVariant<S> for SrcProgram {
             });
 
         let (order, order_ata) = get_order_addresses(test_state);
-        let (whitelist_access, _) =
-            get_whitelist_access_address(&test_state.taker_wallet.keypair.pubkey());
+        let (whitelist_access, _) = get_whitelist_access_address(
+            &cross_chain_escrow_src::ID_CONST,
+            &test_state.taker_wallet.keypair.pubkey(),
+        );
 
         let instruction: Instruction = Instruction {
             program_id: cross_chain_escrow_src::id(),
@@ -232,7 +235,8 @@ pub fn create_public_escrow_cancel_tx<S: TokenVariant>(
         InstructionData::data(&cross_chain_escrow_src::instruction::PublicCancelEscrow {});
 
     let (maker_ata, _) = find_user_ata(test_state);
-    let (whitelist_access, _) = get_whitelist_access_address(&canceller.pubkey());
+    let (whitelist_access, _) =
+        get_whitelist_access_address(&cross_chain_escrow_src::ID_CONST, &canceller.pubkey());
 
     let instruction: Instruction = Instruction {
         program_id: cross_chain_escrow_src::id(),
@@ -290,8 +294,10 @@ pub fn get_rescue_funds_from_order_tx<S: TokenVariant>(
             rescue_amount: test_state.test_arguments.rescue_amount,
         });
 
-    let (whitelist_access, _) =
-        get_whitelist_access_address(&test_state.taker_wallet.keypair.pubkey());
+    let (whitelist_access, _) = get_whitelist_access_address(
+        &cross_chain_escrow_src::ID_CONST,
+        &test_state.taker_wallet.keypair.pubkey(),
+    );
 
     let instruction: Instruction = Instruction {
         program_id: cross_chain_escrow_src::id(),
@@ -492,8 +498,10 @@ pub fn get_cancel_order_by_resolver_tx<T: EscrowVariant<S>, S: TokenVariant>(
     let instruction_data = InstructionData::data(
         &cross_chain_escrow_src::instruction::CancelOrderByResolver { reward_limit },
     );
-    let (whitelist_access, _) =
-        get_whitelist_access_address(&test_state.taker_wallet.keypair.pubkey());
+    let (whitelist_access, _) = get_whitelist_access_address(
+        &cross_chain_escrow_src::ID_CONST,
+        &test_state.taker_wallet.keypair.pubkey(),
+    );
 
     let maker_ata = if let Some(ata) = opt_maker_ata {
         *ata

--- a/common/tests/src/whitelist.rs
+++ b/common/tests/src/whitelist.rs
@@ -161,12 +161,12 @@ pub async fn prepare_resolvers_dst<T: EscrowVariant<S>, S: TokenVariant>(
     test_state: &TestStateBase<T, S>,
     resolvers: &[Pubkey],
 ) {
-    prepare_resolvers(test_state, &cross_chain_escrow_dst::ID_CONST, resolvers).await;
+    prepare_resolvers(test_state, &cross_chain_escrow_dst::ID, resolvers).await;
 }
 
 pub async fn prepare_resolvers_src<T: EscrowVariant<S>, S: TokenVariant>(
     test_state: &TestStateBase<T, S>,
     resolvers: &[Pubkey],
 ) {
-    prepare_resolvers(test_state, &cross_chain_escrow_src::ID_CONST, resolvers).await;
+    prepare_resolvers(test_state, &cross_chain_escrow_src::ID, resolvers).await;
 }

--- a/common/tests/src/whitelist.rs
+++ b/common/tests/src/whitelist.rs
@@ -22,10 +22,12 @@ pub fn get_whitelist_state_address() -> (Pubkey, Pubkey) {
     (whitelist_state, program_id)
 }
 
-pub fn get_whitelist_access_address(user: &Pubkey) -> (Pubkey, u8) {
+pub fn get_whitelist_access_address(client_program: &Pubkey, user: &Pubkey) -> (Pubkey, u8) {
     let program_id = whitelist::id();
-    let (whitelist_access, bump) =
-        Pubkey::find_program_address(&[b"resolver_access", user.as_ref()], &program_id);
+    let (whitelist_access, bump) = Pubkey::find_program_address(
+        &[b"resolver_access", client_program.as_ref(), user.as_ref()],
+        &program_id,
+    );
     (whitelist_access, bump)
 }
 
@@ -69,11 +71,12 @@ pub async fn init_whitelist<T: EscrowVariant<S>, S: TokenVariant>(
 
 pub fn register_deregister_data<T: EscrowVariant<S>, S: TokenVariant>(
     test_state: &TestStateBase<T, S>,
+    client_program: Pubkey,
     whitelisted_account: Pubkey,
     instruction_data: Vec<u8>,
 ) -> (Pubkey, Transaction) {
     let (whitelist_state, program_id) = get_whitelist_state_address();
-    let (whitelist_access, _) = get_whitelist_access_address(&whitelisted_account);
+    let (whitelist_access, _) = get_whitelist_access_address(&client_program, &whitelisted_account);
 
     let instruction: Instruction = Instruction {
         program_id,
@@ -96,14 +99,20 @@ pub fn register_deregister_data<T: EscrowVariant<S>, S: TokenVariant>(
 
 pub async fn register<T: EscrowVariant<S>, S: TokenVariant>(
     test_state: &TestStateBase<T, S>,
+    client_program: Pubkey,
     whitelisted_account: Pubkey,
 ) -> Pubkey {
     let instruction_data = InstructionData::data(&whitelist::instruction::Register {
         _user: whitelisted_account,
+        _client: client_program,
     });
 
-    let (whitelist_access, tx) =
-        register_deregister_data(test_state, whitelisted_account, instruction_data);
+    let (whitelist_access, tx) = register_deregister_data(
+        test_state,
+        client_program,
+        whitelisted_account,
+        instruction_data,
+    );
     test_state
         .client
         .process_transaction(tx)
@@ -114,14 +123,20 @@ pub async fn register<T: EscrowVariant<S>, S: TokenVariant>(
 
 pub async fn deregister<T: EscrowVariant<S>, S: TokenVariant>(
     test_state: &TestStateBase<T, S>,
+    client_program: Pubkey,
     whitelisted_account: Pubkey,
 ) -> Pubkey {
     let instruction_data = InstructionData::data(&whitelist::instruction::Deregister {
         _user: whitelisted_account,
+        _client: client_program,
     });
 
-    let (whitelist_access, tx) =
-        register_deregister_data(test_state, whitelisted_account, instruction_data);
+    let (whitelist_access, tx) = register_deregister_data(
+        test_state,
+        client_program,
+        whitelisted_account,
+        instruction_data,
+    );
     test_state
         .client
         .process_transaction(tx)
@@ -132,11 +147,26 @@ pub async fn deregister<T: EscrowVariant<S>, S: TokenVariant>(
 
 pub async fn prepare_resolvers<T: EscrowVariant<S>, S: TokenVariant>(
     test_state: &TestStateBase<T, S>,
+    client_program: &Pubkey,
     resolvers: &[Pubkey],
 ) {
     init_whitelist(test_state).await;
 
     for resolver in resolvers {
-        register(test_state, *resolver).await;
+        register(test_state, *client_program, *resolver).await;
     }
+}
+
+pub async fn prepare_resolvers_dst<T: EscrowVariant<S>, S: TokenVariant>(
+    test_state: &TestStateBase<T, S>,
+    resolvers: &[Pubkey],
+) {
+    prepare_resolvers(test_state, &cross_chain_escrow_dst::ID_CONST, resolvers).await;
+}
+
+pub async fn prepare_resolvers_src<T: EscrowVariant<S>, S: TokenVariant>(
+    test_state: &TestStateBase<T, S>,
+    resolvers: &[Pubkey],
+) {
+    prepare_resolvers(test_state, &cross_chain_escrow_src::ID_CONST, resolvers).await;
 }

--- a/common/tests/src/whitelist.rs
+++ b/common/tests/src/whitelist.rs
@@ -24,10 +24,8 @@ pub fn get_whitelist_state_address() -> (Pubkey, Pubkey) {
 
 pub fn get_whitelist_access_address(client_program: &Pubkey, user: &Pubkey) -> (Pubkey, u8) {
     let program_id = whitelist::id();
-    let (whitelist_access, bump) = Pubkey::find_program_address(
-        &[b"resolver_access", client_program.as_ref(), user.as_ref()],
-        &program_id,
-    );
+    let (whitelist_access, bump) =
+        Pubkey::find_program_address(&[client_program.as_ref(), user.as_ref()], &program_id);
     (whitelist_access, bump)
 }
 

--- a/programs/cross-chain-escrow-dst/src/lib.rs
+++ b/programs/cross-chain-escrow-dst/src/lib.rs
@@ -321,7 +321,7 @@ pub struct PublicWithdraw<'info> {
     #[account(mut)]
     payer: Signer<'info>,
     #[account(
-        seeds = [whitelist::RESOLVER_ACCESS_SEED, ID_CONST.as_ref(), payer.key().as_ref()],
+        seeds = [whitelist::RESOLVER_ACCESS_SEED, ID.as_ref(), payer.key().as_ref()],
         bump = resolver_access.bump,
         seeds::program = whitelist::ID,
     )]

--- a/programs/cross-chain-escrow-dst/src/lib.rs
+++ b/programs/cross-chain-escrow-dst/src/lib.rs
@@ -321,7 +321,7 @@ pub struct PublicWithdraw<'info> {
     #[account(mut)]
     payer: Signer<'info>,
     #[account(
-        seeds = [whitelist::RESOLVER_ACCESS_SEED, ID.as_ref(), payer.key().as_ref()],
+        seeds = [ID.as_ref(), payer.key().as_ref()],
         bump = resolver_access.bump,
         seeds::program = whitelist::ID,
     )]

--- a/programs/cross-chain-escrow-dst/src/lib.rs
+++ b/programs/cross-chain-escrow-dst/src/lib.rs
@@ -321,7 +321,7 @@ pub struct PublicWithdraw<'info> {
     #[account(mut)]
     payer: Signer<'info>,
     #[account(
-        seeds = [whitelist::RESOLVER_ACCESS_SEED, payer.key().as_ref()],
+        seeds = [whitelist::RESOLVER_ACCESS_SEED, ID_CONST.as_ref(), payer.key().as_ref()],
         bump = resolver_access.bump,
         seeds::program = whitelist::ID,
     )]

--- a/programs/cross-chain-escrow-dst/tests/test_cross_chain_escrow_dst_native.rs
+++ b/programs/cross-chain-escrow-dst/tests/test_cross_chain_escrow_dst_native.rs
@@ -3,7 +3,7 @@ use common::{error::EscrowError, timelocks::Stage};
 use common_tests::dst_program::DstProgram;
 use common_tests::helpers::*;
 use common_tests::tests as common_escrow_tests;
-use common_tests::whitelist::prepare_resolvers;
+use common_tests::whitelist::prepare_resolvers_dst;
 use solana_program::program_error::ProgramError;
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair};
@@ -126,7 +126,7 @@ mod test_escrow_native {
         test_state.token = NATIVE_MINT;
         test_state.test_arguments.asset_is_native = true;
         let withdrawer = test_state.maker_wallet.keypair.insecure_clone();
-        prepare_resolvers(test_state, &[withdrawer.pubkey()]).await;
+        prepare_resolvers_dst(test_state, &[withdrawer.pubkey()]).await;
         let (escrow, escrow_ata) = create_escrow(test_state).await;
 
         let transaction =
@@ -188,7 +188,7 @@ mod test_escrow_native {
         test_state.token = NATIVE_MINT;
         test_state.test_arguments.asset_is_native = true;
         let withdrawer = Keypair::new();
-        prepare_resolvers(test_state, &[withdrawer.pubkey()]).await;
+        prepare_resolvers_dst(test_state, &[withdrawer.pubkey()]).await;
         let payer_kp = &test_state.payer_kp;
         {
             let context = &mut test_state.context;
@@ -301,7 +301,7 @@ mod test_escrow_native {
     #[test_context(TestState)]
     #[tokio::test]
     async fn test_rescue_all_tokens_and_close_ata(test_state: &mut TestState) {
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_dst(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         test_state.token = NATIVE_MINT;
         test_state.test_arguments.asset_is_native = true;
         common_escrow_tests::test_rescue_all_tokens_and_close_ata(test_state).await
@@ -310,7 +310,7 @@ mod test_escrow_native {
     #[test_context(TestState)]
     #[tokio::test]
     async fn test_rescue_part_of_tokens_and_not_close_ata(test_state: &mut TestState) {
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_dst(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         test_state.token = NATIVE_MINT;
         test_state.test_arguments.asset_is_native = true;
         common_escrow_tests::test_rescue_part_of_tokens_and_not_close_ata(test_state).await
@@ -421,7 +421,7 @@ mod test_escrow_wrapped_native {
     async fn test_public_withdraw_by_maker(test_state: &mut TestState) {
         test_state.token = NATIVE_MINT;
         let withdrawer = test_state.maker_wallet.keypair.insecure_clone();
-        prepare_resolvers(test_state, &[withdrawer.pubkey()]).await;
+        prepare_resolvers_dst(test_state, &[withdrawer.pubkey()]).await;
         let (escrow, escrow_ata) = create_escrow(test_state).await;
 
         let transaction =
@@ -496,7 +496,7 @@ mod test_escrow_wrapped_native {
             &withdrawer.pubkey(),
         )
         .await;
-        prepare_resolvers(test_state, &[withdrawer.pubkey()]).await;
+        prepare_resolvers_dst(test_state, &[withdrawer.pubkey()]).await;
         let (escrow, escrow_ata) = create_escrow(test_state).await;
 
         let transaction =
@@ -569,7 +569,7 @@ mod test_escrow_wrapped_native {
     async fn test_public_withdraw_fails_with_no_taker_ata(test_state: &mut TestState) {
         test_state.token = NATIVE_MINT;
         let withdrawer = Keypair::new();
-        prepare_resolvers(test_state, &[withdrawer.pubkey()]).await;
+        prepare_resolvers_dst(test_state, &[withdrawer.pubkey()]).await;
         let payer_kp = &test_state.payer_kp;
         let context = &mut test_state.context;
 
@@ -617,7 +617,7 @@ mod test_escrow_wrapped_native {
     #[test_context(TestState)]
     #[tokio::test]
     async fn test_rescue_all_tokens_and_close_ata(test_state: &mut TestState) {
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_dst(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         test_state.token = NATIVE_MINT;
         common_escrow_tests::test_rescue_all_tokens_and_close_ata(test_state).await
     }
@@ -625,7 +625,7 @@ mod test_escrow_wrapped_native {
     #[test_context(TestState)]
     #[tokio::test]
     async fn test_rescue_part_of_tokens_and_not_close_ata(test_state: &mut TestState) {
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_dst(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         test_state.token = NATIVE_MINT;
         common_escrow_tests::test_rescue_part_of_tokens_and_not_close_ata(test_state).await
     }

--- a/programs/cross-chain-escrow-dst/tests/test_cross_chain_escrow_dst_native.rs
+++ b/programs/cross-chain-escrow-dst/tests/test_cross_chain_escrow_dst_native.rs
@@ -394,7 +394,7 @@ mod test_escrow_wrapped_native {
 
         let (escrow, escrow_ata) = create_escrow(test_state).await;
 
-        test_state.taker_wallet.native_token_account = cross_chain_escrow_dst::ID_CONST;
+        test_state.taker_wallet.native_token_account = cross_chain_escrow_dst::ID;
 
         let transaction = DstProgram::get_withdraw_tx(test_state, &escrow, &escrow_ata);
 
@@ -583,7 +583,7 @@ mod test_escrow_wrapped_native {
 
         let (escrow, escrow_ata) = create_escrow(test_state).await;
 
-        test_state.taker_wallet.native_token_account = cross_chain_escrow_dst::ID_CONST;
+        test_state.taker_wallet.native_token_account = cross_chain_escrow_dst::ID;
 
         let transaction =
             DstProgram::get_public_withdraw_tx(test_state, &escrow, &escrow_ata, &withdrawer);

--- a/programs/cross-chain-escrow-dst/tests/test_cross_chain_escrow_dst_spl.rs
+++ b/programs/cross-chain-escrow-dst/tests/test_cross_chain_escrow_dst_spl.rs
@@ -4,7 +4,7 @@ use common_tests::dst_program::DstProgram;
 use common_tests::helpers::*;
 use common_tests::run_for_tokens;
 use common_tests::tests as common_escrow_tests;
-use common_tests::whitelist::prepare_resolvers;
+use common_tests::whitelist::prepare_resolvers_dst;
 use solana_program::program_error::ProgramError;
 use solana_program_test::tokio;
 use solana_sdk::{signature::Signer, signer::keypair::Keypair, sysvar::clock::Clock};
@@ -297,7 +297,7 @@ run_for_tokens!(
             async fn test_public_withdraw_fails_before_start_of_public_withdraw(
                 test_state: &mut TestState,
             ) {
-                prepare_resolvers(test_state, &[test_state.context.payer.pubkey()]).await;
+                prepare_resolvers_dst(test_state, &[test_state.context.payer.pubkey()]).await;
                 common_escrow_tests::test_public_withdraw_fails_before_start_of_public_withdraw(
                     test_state,
                 )
@@ -309,7 +309,7 @@ run_for_tokens!(
             async fn test_public_withdraw_fails_after_cancellation_start(
                 test_state: &mut TestState,
             ) {
-                prepare_resolvers(test_state, &[test_state.context.payer.pubkey()]).await;
+                prepare_resolvers_dst(test_state, &[test_state.context.payer.pubkey()]).await;
                 common_escrow_tests::test_public_withdraw_fails_after_cancellation_start(test_state)
                     .await
             }
@@ -317,7 +317,8 @@ run_for_tokens!(
             #[test_context(TestState)]
             #[tokio::test]
             async fn test_public_withdraw_tokens_by_maker(test_state: &mut TestState) {
-                prepare_resolvers(test_state, &[test_state.maker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_dst(test_state, &[test_state.maker_wallet.keypair.pubkey()])
+                    .await;
                 let (escrow, escrow_ata) = create_escrow(test_state).await;
 
                 let transaction = DstProgram::get_public_withdraw_tx(
@@ -389,7 +390,7 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_public_withdraw_tokens_by_any_resolver(test_state: &mut TestState) {
                 let withdrawer = Keypair::new();
-                prepare_resolvers(test_state, &[withdrawer.pubkey()]).await;
+                prepare_resolvers_dst(test_state, &[withdrawer.pubkey()]).await;
                 transfer_lamports(
                     &mut test_state.context,
                     WALLET_DEFAULT_LAMPORTS,
@@ -480,7 +481,8 @@ run_for_tokens!(
             async fn test_public_withdraw_fails_if_public_withdrawal_duration_overflows(
                 test_state: &mut TestState,
             ) {
-                prepare_resolvers(test_state, &[test_state.maker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_dst(test_state, &[test_state.maker_wallet.keypair.pubkey()])
+                    .await;
                 test_state.test_arguments.dst_timelocks =
                     init_timelocks(0, 0, 0, 0, 0, u32::MAX, 0, 0);
                 let (escrow, escrow_ata) = create_escrow(test_state).await;
@@ -502,14 +504,15 @@ run_for_tokens!(
             #[test_context(TestState)]
             #[tokio::test]
             async fn test_public_withdraw_fails_with_wrong_secret(test_state: &mut TestState) {
-                prepare_resolvers(test_state, &[test_state.context.payer.pubkey()]).await;
+                prepare_resolvers_dst(test_state, &[test_state.context.payer.pubkey()]).await;
                 common_escrow_tests::test_public_withdraw_fails_with_wrong_secret(test_state).await
             }
 
             #[test_context(TestState)]
             #[tokio::test]
             async fn test_public_withdraw_fails_with_wrong_taker_ata(test_state: &mut TestState) {
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_dst(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 common_escrow_tests::test_public_withdraw_fails_with_wrong_taker_ata(test_state)
                     .await
             }
@@ -517,7 +520,8 @@ run_for_tokens!(
             #[test_context(TestState)]
             #[tokio::test]
             async fn test_public_withdraw_fails_with_wrong_escrow_ata(test_state: &mut TestState) {
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_dst(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let new_escrow_amount = test_state.test_arguments.escrow_amount + 1;
                 common_escrow_tests::test_public_withdraw_fails_with_wrong_escrow_ata(
                     test_state,
@@ -572,7 +576,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_public_withdraw_fails_with_incorrect_token(test_state: &mut TestState) {
                 let (escrow, escrow_ata) = create_escrow(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_dst(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 test_state.token = <TestState as HasTokenVariant>::Token::deploy_spl_token(
                     &mut test_state.context,
@@ -688,28 +693,32 @@ run_for_tokens!(
             #[test_context(TestState)]
             #[tokio::test]
             async fn test_rescue_all_tokens_and_close_ata(test_state: &mut TestState) {
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_dst(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 common_escrow_tests::test_rescue_all_tokens_and_close_ata(test_state).await
             }
 
             #[test_context(TestState)]
             #[tokio::test]
             async fn test_rescue_part_of_tokens_and_not_close_ata(test_state: &mut TestState) {
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_dst(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 common_escrow_tests::test_rescue_part_of_tokens_and_not_close_ata(test_state).await
             }
 
             #[test_context(TestState)]
             #[tokio::test]
             async fn test_rescue_tokens_when_escrow_is_deleted(test_state: &mut TestState) {
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_dst(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 common_escrow_tests::test_rescue_tokens_when_escrow_is_deleted(test_state).await;
             }
 
             #[test_context(TestState)]
             #[tokio::test]
             async fn test_cannot_rescue_funds_before_rescue_delay_pass(test_state: &mut TestState) {
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_dst(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 common_escrow_tests::test_cannot_rescue_funds_before_rescue_delay_pass(test_state)
                     .await
             }
@@ -718,21 +727,23 @@ run_for_tokens!(
             // #[test_context(TestState)]
             // #[tokio::test]
             // async fn test_cannot_rescue_funds_by_non_recipient(test_state: &mut TestState) {
-            //     prepare_resolvers(test_state, &[test_state.maker_wallet.keypair.pubkey()]).await;
+            //     prepare_resolvers_dst(test_state, &[test_state.maker_wallet.keypair.pubkey()]).await;
             //     common_escrow_tests::test_cannot_rescue_funds_by_non_recipient(test_state).await
             // }
 
             #[test_context(TestState)]
             #[tokio::test]
             async fn test_cannot_rescue_funds_with_wrong_taker_ata(test_state: &mut TestState) {
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_dst(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 common_escrow_tests::test_cannot_rescue_funds_with_wrong_taker_ata(test_state).await
             }
 
             #[test_context(TestState)]
             #[tokio::test]
             async fn test_cannot_rescue_funds_with_wrong_escrow_ata(test_state: &mut TestState) {
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_dst(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 common_escrow_tests::test_cannot_rescue_funds_with_wrong_escrow_ata(test_state)
                     .await
             }

--- a/programs/cross-chain-escrow-dst/tests/test_cross_chain_escrow_dst_spl.rs
+++ b/programs/cross-chain-escrow-dst/tests/test_cross_chain_escrow_dst_spl.rs
@@ -559,7 +559,7 @@ run_for_tokens!(
                 .await;
 
                 let withdrawer = Keypair::new();
-                prepare_resolvers(test_state, &[withdrawer.pubkey()]).await;
+                prepare_resolvers_dst(test_state, &[withdrawer.pubkey()]).await;
                 transfer_lamports(
                     &mut test_state.context,
                     WALLET_DEFAULT_LAMPORTS,

--- a/programs/cross-chain-escrow-src/src/lib.rs
+++ b/programs/cross-chain-escrow-src/src/lib.rs
@@ -672,7 +672,7 @@ pub struct CreateEscrow<'info> {
     #[account(mut)]
     taker: Signer<'info>,
     #[account(
-        seeds = [whitelist::RESOLVER_ACCESS_SEED, ID.as_ref(), taker.key().as_ref()],
+        seeds = [ID.as_ref(), taker.key().as_ref()],
         bump = resolver_access.bump,
         seeds::program = whitelist::ID,
     )]
@@ -798,7 +798,7 @@ pub struct PublicWithdraw<'info> {
     #[account(mut)]
     payer: Signer<'info>,
     #[account(
-        seeds = [whitelist::RESOLVER_ACCESS_SEED, ID.as_ref(), payer.key().as_ref()],
+        seeds = [ID.as_ref(), payer.key().as_ref()],
         bump = resolver_access.bump,
         seeds::program = whitelist::ID,
     )]
@@ -903,7 +903,7 @@ pub struct PublicCancelEscrow<'info> {
     #[account(mut)]
     payer: Signer<'info>,
     #[account(
-        seeds = [whitelist::RESOLVER_ACCESS_SEED, ID.as_ref(), payer.key().as_ref()],
+        seeds = [ID.as_ref(), payer.key().as_ref()],
         bump = resolver_access.bump,
         seeds::program = whitelist::ID,
     )]
@@ -988,7 +988,7 @@ pub struct CancelOrderbyResolver<'info> {
     #[account(mut, signer)]
     resolver: Signer<'info>,
     #[account(
-        seeds = [whitelist::RESOLVER_ACCESS_SEED, ID.as_ref(), resolver.key().as_ref()],
+        seeds = [ID.as_ref(), resolver.key().as_ref()],
         bump = resolver_access.bump,
         seeds::program = whitelist::ID,
     )]
@@ -1095,7 +1095,7 @@ pub struct RescueFundsForOrder<'info> {
     )]
     resolver: Signer<'info>,
     #[account(
-        seeds = [whitelist::RESOLVER_ACCESS_SEED, ID.as_ref(), resolver.key().as_ref()],
+        seeds = [ID.as_ref(), resolver.key().as_ref()],
         bump = resolver_access.bump,
         seeds::program = whitelist::ID,
     )]

--- a/programs/cross-chain-escrow-src/src/lib.rs
+++ b/programs/cross-chain-escrow-src/src/lib.rs
@@ -672,7 +672,7 @@ pub struct CreateEscrow<'info> {
     #[account(mut)]
     taker: Signer<'info>,
     #[account(
-        seeds = [whitelist::RESOLVER_ACCESS_SEED, taker.key().as_ref()],
+        seeds = [whitelist::RESOLVER_ACCESS_SEED, ID.as_ref(), taker.key().as_ref()],
         bump = resolver_access.bump,
         seeds::program = whitelist::ID,
     )]
@@ -798,7 +798,7 @@ pub struct PublicWithdraw<'info> {
     #[account(mut)]
     payer: Signer<'info>,
     #[account(
-        seeds = [whitelist::RESOLVER_ACCESS_SEED, payer.key().as_ref()],
+        seeds = [whitelist::RESOLVER_ACCESS_SEED, ID.as_ref(), payer.key().as_ref()],
         bump = resolver_access.bump,
         seeds::program = whitelist::ID,
     )]
@@ -903,7 +903,7 @@ pub struct PublicCancelEscrow<'info> {
     #[account(mut)]
     payer: Signer<'info>,
     #[account(
-        seeds = [whitelist::RESOLVER_ACCESS_SEED, payer.key().as_ref()],
+        seeds = [whitelist::RESOLVER_ACCESS_SEED, ID.as_ref(), payer.key().as_ref()],
         bump = resolver_access.bump,
         seeds::program = whitelist::ID,
     )]
@@ -988,7 +988,7 @@ pub struct CancelOrderbyResolver<'info> {
     #[account(mut, signer)]
     resolver: Signer<'info>,
     #[account(
-        seeds = [whitelist::RESOLVER_ACCESS_SEED, resolver.key().as_ref()],
+        seeds = [whitelist::RESOLVER_ACCESS_SEED, ID.as_ref(), resolver.key().as_ref()],
         bump = resolver_access.bump,
         seeds::program = whitelist::ID,
     )]
@@ -1095,7 +1095,7 @@ pub struct RescueFundsForOrder<'info> {
     )]
     resolver: Signer<'info>,
     #[account(
-        seeds = [whitelist::RESOLVER_ACCESS_SEED, resolver.key().as_ref()],
+        seeds = [whitelist::RESOLVER_ACCESS_SEED, ID.as_ref(), resolver.key().as_ref()],
         bump = resolver_access.bump,
         seeds::program = whitelist::ID,
     )]

--- a/programs/cross-chain-escrow-src/tests/helpers_src.rs
+++ b/programs/cross-chain-escrow-src/tests/helpers_src.rs
@@ -17,7 +17,7 @@ use common_tests::src_program::{
     get_cancel_order_by_resolver_tx, get_cancel_order_tx, get_order_addresses,
     get_rescue_funds_from_order_tx, SrcProgram,
 };
-use common_tests::whitelist::prepare_resolvers;
+use common_tests::whitelist::prepare_resolvers_src;
 use cross_chain_escrow_src::calculate_premium;
 use cross_chain_escrow_src::merkle_tree::MerkleProof;
 use primitive_types::U256;
@@ -675,7 +675,7 @@ pub async fn test_cancel_by_resolver_at_different_points<S: TokenVariant>(
                     / (100 * 100)
         })
         .collect();
-    prepare_resolvers(
+    prepare_resolvers_src(
         init_test_state,
         &[init_test_state.taker_wallet.keypair.pubkey()],
     )
@@ -693,7 +693,7 @@ pub async fn test_cancel_by_resolver_at_different_points<S: TokenVariant>(
             // Create a new test state for each cancellation point and premium
             let mut test_state =
                 reset_test_state(PhantomData::<TestStateBase<SrcProgram, S>>).await;
-            prepare_resolvers(&test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+            prepare_resolvers_src(&test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
 
             // Set max cancellation premium
             test_state.test_arguments.max_cancellation_premium = max_cancellation_premium as u64;

--- a/programs/cross-chain-escrow-src/tests/test_cross_chain_escrow_src_native.rs
+++ b/programs/cross-chain-escrow-src/tests/test_cross_chain_escrow_src_native.rs
@@ -9,7 +9,7 @@ use common_tests::src_program::{
 };
 
 use common_tests::tests as common_escrow_tests;
-use common_tests::whitelist::prepare_resolvers;
+use common_tests::whitelist::prepare_resolvers_src;
 use solana_program_test::tokio;
 use solana_sdk::signature::Signer;
 use solana_sdk::signer::keypair::Keypair;
@@ -41,7 +41,7 @@ mod test_native_src {
         test_state.token = NATIVE_MINT;
         test_state.test_arguments.asset_is_native = true;
         create_order(test_state).await;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         let (escrow, escrow_ata) = create_escrow(test_state).await;
 
         // Check the lamport X of escrow account is as expected.
@@ -94,7 +94,7 @@ mod test_native_src {
         test_state.token = NATIVE_MINT;
         test_state.test_arguments.asset_is_native = true;
         create_order(test_state).await;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         let (escrow, escrow_ata) = create_escrow(test_state).await;
         helpers_src::test_withdraw_escrow(test_state, &escrow, &escrow_ata).await;
     }
@@ -106,7 +106,7 @@ mod test_native_src {
         test_state.test_arguments.asset_is_native = true;
         create_order(test_state).await;
         let withdrawer = test_state.taker_wallet.keypair.insecure_clone();
-        prepare_resolvers(test_state, &[withdrawer.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[withdrawer.pubkey()]).await;
         let (escrow, escrow_ata) = create_escrow(test_state).await;
 
         let transaction =
@@ -179,7 +179,7 @@ mod test_native_src {
             &withdrawer.pubkey(),
         )
         .await;
-        prepare_resolvers(
+        prepare_resolvers_src(
             test_state,
             &[
                 withdrawer.pubkey(),
@@ -252,7 +252,7 @@ mod test_native_src {
     async fn test_order_cancel(test_state: &mut TestState) {
         test_state.token = NATIVE_MINT;
         test_state.test_arguments.asset_is_native = true;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         helpers_src::test_order_cancel(test_state).await;
     }
 
@@ -292,7 +292,7 @@ mod test_native_src {
     async fn test_cancel_by_resolver_for_free_at_the_auction_start(test_state: &mut TestState) {
         test_state.token = NATIVE_MINT;
         test_state.test_arguments.asset_is_native = true;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         helpers_src::test_cancel_by_resolver_for_free_at_the_auction_start(test_state).await;
     }
 
@@ -312,7 +312,7 @@ mod test_native_src {
     async fn test_cancel_by_resolver_after_auction(test_state: &mut TestState) {
         test_state.token = NATIVE_MINT;
         test_state.test_arguments.asset_is_native = true;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         helpers_src::test_cancel_by_resolver_after_auction(test_state).await;
     }
 
@@ -323,7 +323,7 @@ mod test_native_src {
     ) {
         test_state.token = NATIVE_MINT;
         test_state.test_arguments.asset_is_native = true;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         helpers_src::test_cancel_by_resolver_reward_less_then_auction_calculated(test_state).await;
     }
 
@@ -336,7 +336,7 @@ mod test_native_src {
         test_state.test_arguments.asset_is_native = true;
         let (order, order_ata) = create_order(test_state).await;
 
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         set_time(
             &mut test_state.context,
             test_state.test_arguments.expiration_time,
@@ -364,7 +364,7 @@ mod test_native_src {
         test_state.token = NATIVE_MINT;
         test_state.test_arguments.asset_is_native = true;
         create_order(test_state).await;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         let (escrow, escrow_ata) = create_escrow(test_state).await;
         let transaction = SrcProgram::get_cancel_tx(test_state, &escrow, &escrow_ata);
 
@@ -409,7 +409,7 @@ mod test_native_src {
         create_order(test_state).await;
 
         let canceller = Keypair::new();
-        prepare_resolvers(
+        prepare_resolvers_src(
             test_state,
             &[test_state.taker_wallet.keypair.pubkey(), canceller.pubkey()],
         )
@@ -483,7 +483,7 @@ mod test_native_src {
         test_state.token = NATIVE_MINT;
         test_state.test_arguments.asset_is_native = true;
         create_order(test_state).await;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         common_escrow_tests::test_rescue_all_tokens_and_close_ata(test_state).await
     }
 
@@ -493,7 +493,7 @@ mod test_native_src {
         test_state.token = NATIVE_MINT;
         test_state.test_arguments.asset_is_native = true;
         create_order(test_state).await;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         common_escrow_tests::test_rescue_part_of_tokens_and_not_close_ata(test_state).await
     }
 
@@ -502,7 +502,7 @@ mod test_native_src {
     async fn test_rescue_all_tokens_from_order_and_close_ata(test_state: &mut TestState) {
         test_state.token = NATIVE_MINT;
         test_state.test_arguments.asset_is_native = true;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         helpers_src::test_rescue_all_tokens_from_order_and_close_ata(test_state).await
     }
 
@@ -511,7 +511,7 @@ mod test_native_src {
     async fn test_rescue_part_of_tokens_from_order_and_not_close_ata(test_state: &mut TestState) {
         test_state.token = NATIVE_MINT;
         test_state.test_arguments.asset_is_native = true;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         helpers_src::test_rescue_part_of_tokens_from_order_and_not_close_ata(test_state).await
     }
 }
@@ -526,7 +526,7 @@ mod test_wrapped_native {
     #[tokio::test]
     async fn test_order_creation(test_state: &mut TestState) {
         test_state.token = NATIVE_MINT;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         helpers_src::test_order_creation(test_state).await
     }
 
@@ -535,7 +535,7 @@ mod test_wrapped_native {
     async fn test_escrow_creation(test_state: &mut TestState) {
         test_state.token = NATIVE_MINT;
         create_order(test_state).await;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         common_escrow_tests::test_escrow_creation(test_state).await
     }
 
@@ -544,7 +544,7 @@ mod test_wrapped_native {
     async fn test_withdraw(test_state: &mut TestState) {
         test_state.token = NATIVE_MINT;
         create_order(test_state).await;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         let (escrow, escrow_ata) = create_escrow(test_state).await;
         helpers_src::test_withdraw_escrow(test_state, &escrow, &escrow_ata).await;
     }
@@ -555,7 +555,7 @@ mod test_wrapped_native {
         test_state.token = NATIVE_MINT;
         create_order(test_state).await;
         let withdrawer = test_state.taker_wallet.keypair.insecure_clone();
-        prepare_resolvers(test_state, &[withdrawer.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[withdrawer.pubkey()]).await;
         let (escrow, escrow_ata) = create_escrow(test_state).await;
 
         let transaction =
@@ -624,7 +624,7 @@ mod test_wrapped_native {
             &withdrawer.pubkey(),
         )
         .await;
-        prepare_resolvers(
+        prepare_resolvers_src(
             test_state,
             &[
                 withdrawer.pubkey(),
@@ -733,14 +733,14 @@ mod test_wrapped_native {
     #[tokio::test]
     async fn test_cancel_by_resolver_for_free_at_the_auction_start(test_state: &mut TestState) {
         test_state.token = NATIVE_MINT;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         helpers_src::test_cancel_by_resolver_for_free_at_the_auction_start(test_state).await;
     }
 
     #[test_context(TestState)]
     #[tokio::test]
     async fn test_cancel_by_resolver_at_different_points(test_state: &mut TestState) {
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         helpers_src::test_cancel_by_resolver_at_different_points(
             test_state,
             false,
@@ -753,7 +753,7 @@ mod test_wrapped_native {
     #[tokio::test]
     async fn test_cancel_by_resolver_after_auction(test_state: &mut TestState) {
         test_state.token = NATIVE_MINT;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         helpers_src::test_cancel_by_resolver_after_auction(test_state).await;
     }
 
@@ -763,7 +763,7 @@ mod test_wrapped_native {
         test_state: &mut TestState,
     ) {
         test_state.token = NATIVE_MINT;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         helpers_src::test_cancel_by_resolver_reward_less_then_auction_calculated(test_state).await;
     }
 
@@ -775,7 +775,7 @@ mod test_wrapped_native {
         test_state.token = NATIVE_MINT;
         let (order, order_ata) = create_order(test_state).await;
 
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         set_time(
             &mut test_state.context,
             test_state.test_arguments.expiration_time,
@@ -802,7 +802,7 @@ mod test_wrapped_native {
     async fn test_cancel(test_state: &mut TestState) {
         test_state.token = NATIVE_MINT;
         create_order(test_state).await;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         let (escrow, escrow_ata) = create_escrow(test_state).await;
         common_escrow_tests::test_cancel(test_state, &escrow, &escrow_ata).await
     }
@@ -815,7 +815,7 @@ mod test_wrapped_native {
         create_order(test_state).await;
 
         let canceller = Keypair::new();
-        prepare_resolvers(
+        prepare_resolvers_src(
             test_state,
             &[test_state.taker_wallet.keypair.pubkey(), canceller.pubkey()],
         )
@@ -888,7 +888,7 @@ mod test_wrapped_native {
     async fn test_rescue_all_tokens_and_close_ata(test_state: &mut TestState) {
         test_state.token = NATIVE_MINT;
         create_order(test_state).await;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         common_escrow_tests::test_rescue_all_tokens_and_close_ata(test_state).await
     }
 
@@ -897,7 +897,7 @@ mod test_wrapped_native {
     async fn test_rescue_part_of_tokens_and_not_close_ata(test_state: &mut TestState) {
         test_state.token = NATIVE_MINT;
         create_order(test_state).await;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         common_escrow_tests::test_rescue_part_of_tokens_and_not_close_ata(test_state).await
     }
 }

--- a/programs/cross-chain-escrow-src/tests/test_cross_chain_escrow_src_native_partial_fills.rs
+++ b/programs/cross-chain-escrow-src/tests/test_cross_chain_escrow_src_native_partial_fills.rs
@@ -3,7 +3,7 @@ use common_tests::helpers::*;
 use common_tests::src_program::SrcProgram;
 
 use common_tests::tests as common_escrow_tests;
-use common_tests::whitelist::prepare_resolvers;
+use common_tests::whitelist::prepare_resolvers_src;
 use solana_program_test::tokio;
 use solana_sdk::signature::Signer;
 use solana_sdk::signer::keypair::Keypair;
@@ -26,7 +26,7 @@ mod test_native_src {
         let (order, order_ata) = create_order_for_partial_fill(test_state).await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
 
         test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
 
@@ -46,7 +46,7 @@ mod test_native_src {
         create_order_for_partial_fill(test_state).await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
 
         let secret_index = get_index_for_escrow_amount(test_state, escrow_amount);
 
@@ -65,7 +65,7 @@ mod test_native_src {
         create_order_for_partial_fill(test_state).await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
 
         let secret_index = get_index_for_escrow_amount(test_state, escrow_amount);
 
@@ -92,7 +92,7 @@ mod test_native_src {
         create_order_for_partial_fill(test_state).await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
 
         let secret_index = get_index_for_escrow_amount(test_state, escrow_amount);
 
@@ -116,7 +116,7 @@ mod test_native_src {
         create_order_for_partial_fill(test_state).await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
 
         let secret_index = get_index_for_escrow_amount(test_state, escrow_amount);
 
@@ -158,7 +158,7 @@ mod test_native_src {
         .await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-        prepare_resolvers(
+        prepare_resolvers_src(
             test_state,
             &[
                 test_state.taker_wallet.keypair.pubkey(),
@@ -186,7 +186,7 @@ mod test_native_src {
         create_order_for_partial_fill(test_state).await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
 
         let (escrow, escrow_ata) =
             test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
@@ -202,7 +202,7 @@ mod test_native_src {
         create_order_for_partial_fill(test_state).await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         test_state.test_arguments.escrow_amount = escrow_amount;
         let (escrow, escrow_ata) =
             test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
@@ -222,7 +222,7 @@ mod test_native_src {
         create_order_for_partial_fill(test_state).await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
 
         let (escrow, escrow_ata) =
             test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
@@ -242,7 +242,7 @@ mod test_native_src {
         create_order_for_partial_fill(test_state).await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
 
         let (escrow, escrow_ata) =
             test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
@@ -276,7 +276,7 @@ mod test_native_src {
         .await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-        prepare_resolvers(
+        prepare_resolvers_src(
             test_state,
             &[test_state.taker_wallet.keypair.pubkey(), canceller.pubkey()],
         )
@@ -300,7 +300,7 @@ mod test_wrapped_native {
         let (order, order_ata) = create_order_for_partial_fill(test_state).await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
 
         test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
 
@@ -319,7 +319,7 @@ mod test_wrapped_native {
         create_order_for_partial_fill(test_state).await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
 
         let secret_index = get_index_for_escrow_amount(test_state, escrow_amount);
 
@@ -337,7 +337,7 @@ mod test_wrapped_native {
         create_order_for_partial_fill(test_state).await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
 
         let secret_index = get_index_for_escrow_amount(test_state, escrow_amount);
 
@@ -363,7 +363,7 @@ mod test_wrapped_native {
         create_order_for_partial_fill(test_state).await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
 
         let secret_index = get_index_for_escrow_amount(test_state, escrow_amount);
 
@@ -386,7 +386,7 @@ mod test_wrapped_native {
         create_order_for_partial_fill(test_state).await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
 
         let secret_index = get_index_for_escrow_amount(test_state, escrow_amount);
 
@@ -427,7 +427,7 @@ mod test_wrapped_native {
         .await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-        prepare_resolvers(
+        prepare_resolvers_src(
             test_state,
             &[
                 test_state.taker_wallet.keypair.pubkey(),
@@ -454,7 +454,7 @@ mod test_wrapped_native {
         create_order_for_partial_fill(test_state).await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
 
         let (escrow, escrow_ata) =
             test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
@@ -469,7 +469,7 @@ mod test_wrapped_native {
         create_order_for_partial_fill(test_state).await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
         test_state.test_arguments.escrow_amount = escrow_amount;
         let (escrow, escrow_ata) =
             test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
@@ -488,7 +488,7 @@ mod test_wrapped_native {
         create_order_for_partial_fill(test_state).await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
 
         let (escrow, escrow_ata) =
             test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
@@ -507,7 +507,7 @@ mod test_wrapped_native {
         create_order_for_partial_fill(test_state).await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE;
-        prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+        prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
 
         let (escrow, escrow_ata) =
             test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
@@ -540,7 +540,7 @@ mod test_wrapped_native {
         .await;
 
         let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-        prepare_resolvers(
+        prepare_resolvers_src(
             test_state,
             &[test_state.taker_wallet.keypair.pubkey(), canceller.pubkey()],
         )

--- a/programs/cross-chain-escrow-src/tests/test_cross_chain_escrow_src_partial_fills.rs
+++ b/programs/cross-chain-escrow-src/tests/test_cross_chain_escrow_src_partial_fills.rs
@@ -5,7 +5,7 @@ use common_tests::run_for_tokens;
 use common_tests::src_program::create_public_escrow_cancel_tx;
 use common_tests::src_program::{create_order, SrcProgram};
 use common_tests::tests as common_escrow_tests;
-use common_tests::whitelist::prepare_resolvers;
+use common_tests::whitelist::prepare_resolvers_src;
 use solana_program_test::tokio;
 use solana_sdk::{keccak::hashv, signature::Signer, signer::keypair::Keypair};
 use test_context::test_context;
@@ -35,7 +35,8 @@ run_for_tokens!(
                 let (order, order_ata) = create_order_for_partial_fill(test_state).await;
 
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
 
@@ -53,7 +54,8 @@ run_for_tokens!(
                 let (order, order_ata) = create_order_for_partial_fill(test_state).await;
 
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
                 test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
@@ -72,7 +74,8 @@ run_for_tokens!(
                 test_state: &mut TestState,
             ) {
                 let (order, order_ata) = create_order_for_partial_fill(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 test_escrow_creation_for_partial_fill(test_state, DEFAULT_ESCROW_AMOUNT).await;
 
@@ -90,7 +93,8 @@ run_for_tokens!(
                 let (order, order_ata) = create_order_for_partial_fill(test_state).await;
 
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
                 test_escrow_creation_for_partial_fill(
@@ -115,7 +119,8 @@ run_for_tokens!(
                 let (order, order_ata) = create_order_for_partial_fill(test_state).await;
 
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
 
@@ -148,7 +153,8 @@ run_for_tokens!(
                 create_order_for_partial_fill(test_state).await;
 
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (escrow, _) =
                     test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
 
@@ -179,7 +185,8 @@ run_for_tokens!(
             ) {
                 create_order_for_partial_fill(test_state).await;
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
                 let (_, _, transaction) = test_escrow_creation_for_partial_fill_data(
@@ -203,7 +210,8 @@ run_for_tokens!(
                 create_order_for_partial_fill(test_state).await;
 
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE + 1;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
                 let so_small_escrow_amount = 1;
@@ -242,7 +250,8 @@ run_for_tokens!(
                     hashed_secret,
                 };
                 test_state.test_arguments.merkle_proof = Some(proof);
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (_, _, transaction) = create_escrow_data(test_state);
 
                 test_state
@@ -275,7 +284,8 @@ run_for_tokens!(
                     hashed_secret: merkle_hashes.hashed_secrets[index_to_validate + 1],
                 };
                 test_state.test_arguments.merkle_proof = Some(proof);
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (_, _, transaction) = create_escrow_data(test_state);
 
                 test_state
@@ -289,7 +299,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_create_escrow_fails_without_merkle_proof(test_state: &mut TestState) {
                 create_order_for_partial_fill(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 // test_state.test_arguments.merkle_proof is none
                 let (_, _, transaction) = create_escrow_data(test_state);
@@ -327,7 +338,8 @@ run_for_tokens!(
                     hashed_secret,
                 };
                 test_state.test_arguments.merkle_proof = Some(proof);
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (_, _, transaction) = create_escrow_data(test_state);
 
                 test_state
@@ -349,7 +361,8 @@ run_for_tokens!(
                 create_order_for_partial_fill(test_state).await;
 
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 let secret_index = get_index_for_escrow_amount(test_state, escrow_amount);
 
@@ -366,7 +379,8 @@ run_for_tokens!(
                 create_order_for_partial_fill(test_state).await;
 
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 let secret_index = get_index_for_escrow_amount(test_state, escrow_amount);
 
@@ -393,7 +407,8 @@ run_for_tokens!(
                 create_order_for_partial_fill(test_state).await;
 
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 let (escrow, escrow_ata) =
                     test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
@@ -424,7 +439,8 @@ run_for_tokens!(
                 create_order_for_partial_fill(test_state).await;
 
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 let (_, escrow_ata) =
                     test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
@@ -464,7 +480,8 @@ run_for_tokens!(
                 create_order_for_partial_fill(test_state).await;
 
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 let secret_index = get_index_for_escrow_amount(test_state, escrow_amount);
 
@@ -492,7 +509,8 @@ run_for_tokens!(
                 create_order_for_partial_fill(test_state).await;
 
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 let secret_index = get_index_for_escrow_amount(test_state, escrow_amount);
 
@@ -545,7 +563,7 @@ run_for_tokens!(
                 .await;
 
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-                prepare_resolvers(
+                prepare_resolvers_src(
                     test_state,
                     &[
                         test_state.taker_wallet.keypair.pubkey(),
@@ -576,7 +594,8 @@ run_for_tokens!(
                 create_order_for_partial_fill(test_state).await;
 
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 let (_, escrow_ata) =
                     test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
@@ -619,7 +638,8 @@ run_for_tokens!(
                 create_order_for_partial_fill(test_state).await;
 
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 let (escrow, escrow_ata) =
                     test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
@@ -633,7 +653,8 @@ run_for_tokens!(
                 create_order_for_partial_fill(test_state).await;
 
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 let (escrow, escrow_ata) =
                     test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
@@ -651,7 +672,8 @@ run_for_tokens!(
                 create_order_for_partial_fill(test_state).await;
 
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 let (_, escrow_ata) =
                     test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
@@ -692,7 +714,8 @@ run_for_tokens!(
                 create_order_for_partial_fill(test_state).await;
 
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 let (escrow, escrow_ata) =
                     test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
@@ -710,7 +733,8 @@ run_for_tokens!(
                 create_order_for_partial_fill(test_state).await;
 
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 let (escrow, escrow_ata) =
                     test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;
@@ -744,7 +768,7 @@ run_for_tokens!(
                 .await;
 
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE * 3;
-                prepare_resolvers(
+                prepare_resolvers_src(
                     test_state,
                     &[test_state.taker_wallet.keypair.pubkey(), canceller.pubkey()],
                 )
@@ -762,7 +786,8 @@ run_for_tokens!(
                 create_order_for_partial_fill(test_state).await;
 
                 let escrow_amount = DEFAULT_ESCROW_AMOUNT / DEFAULT_PARTS_AMOUNT_FOR_MULTIPLE;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 let (_, escrow_ata) =
                     test_escrow_creation_for_partial_fill(test_state, escrow_amount).await;

--- a/programs/cross-chain-escrow-src/tests/test_cross_chain_escrow_src_spl.rs
+++ b/programs/cross-chain-escrow-src/tests/test_cross_chain_escrow_src_spl.rs
@@ -8,7 +8,7 @@ use common_tests::src_program::{
     get_rescue_funds_from_order_tx, SrcProgram,
 };
 use common_tests::tests as common_escrow_tests;
-use common_tests::whitelist::prepare_resolvers;
+use common_tests::whitelist::prepare_resolvers_src;
 use solana_program_test::tokio;
 use solana_sdk::signature::Signer;
 use solana_sdk::signer::keypair::Keypair;
@@ -213,7 +213,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_escrow_creation(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 common_escrow_tests::test_escrow_creation(test_state).await;
             }
 
@@ -221,7 +222,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_escrow_creation_with_pre_existing_escrow_ata(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (escrow_pda, _) =
                     get_escrow_addresses(test_state, test_state.taker_wallet.keypair.pubkey());
 
@@ -252,7 +254,8 @@ run_for_tokens!(
                     };
 
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 common_escrow_tests::test_escrow_creation(test_state).await
             }
 
@@ -261,7 +264,8 @@ run_for_tokens!(
             async fn test_escrow_creation_with_excess_tokens(test_state: &mut TestState) {
                 type S = <TestState as HasTokenVariant>::Token;
 
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (_, order_ata) = create_order(test_state).await;
                 let excess_amount = 1000;
                 // Send excess tokens to the order ATA.
@@ -318,7 +322,8 @@ run_for_tokens!(
                             },
                         ],
                     };
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (_, _, tx) = create_escrow_data(test_state);
                 test_state
                     .client
@@ -347,7 +352,8 @@ run_for_tokens!(
 
                 create_order(test_state).await;
 
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (escrow, _) = create_escrow(test_state).await;
                 let escrow_account_data = test_state
                     .client
@@ -373,7 +379,8 @@ run_for_tokens!(
                 test_state: &mut TestState,
             ) {
                 // Create an escrow account without existing order account.
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (escrow, escrow_ata, tx) = create_escrow_data(test_state);
 
                 test_state
@@ -397,7 +404,8 @@ run_for_tokens!(
             async fn test_escrow_creation_fails_with_expired_order(test_state: &mut TestState) {
                 create_order(test_state).await;
 
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 set_time(
                     &mut test_state.context,
                     test_state.test_arguments.expiration_time + 1,
@@ -418,7 +426,8 @@ run_for_tokens!(
                 test_state: &mut TestState,
             ) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 test_state.test_arguments.escrow_amount =
                     test_state.test_arguments.order_amount + 1;
                 let (_, _, transaction) = create_escrow_data(test_state);
@@ -449,7 +458,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_escrow_creation_fails_with_incorrect_token(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 test_state.token = <TestState as HasTokenVariant>::Token::deploy_spl_token(
                     &mut test_state.context,
                 )
@@ -472,7 +482,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_withdraw(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (escrow, escrow_ata) = create_escrow(test_state).await;
                 helpers_src::test_withdraw_escrow(test_state, &escrow, &escrow_ata).await;
             }
@@ -481,7 +492,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_withdraw_with_excess_tokens(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (escrow, escrow_ata) = create_escrow(test_state).await;
                 let transaction = SrcProgram::get_withdraw_tx(test_state, &escrow, &escrow_ata);
 
@@ -530,7 +542,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_withdraw_does_not_work_with_wrong_secret(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 common_escrow_tests::test_withdraw_does_not_work_with_wrong_secret(test_state).await
             }
 
@@ -538,7 +551,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_withdraw_does_not_work_with_non_recipient(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 common_escrow_tests::test_withdraw_does_not_work_with_non_recipient(test_state)
                     .await
             }
@@ -547,7 +561,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_withdraw_does_not_work_with_wrong_taker_ata(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 common_escrow_tests::test_withdraw_does_not_work_with_wrong_taker_ata(test_state)
                     .await
             }
@@ -561,7 +576,8 @@ run_for_tokens!(
                 create_order(test_state).await;
                 test_state.test_arguments.order_amount -= diff_amount;
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 common_escrow_tests::test_withdraw_does_not_work_with_wrong_escrow_ata(
                     test_state, new_amount,
                 )
@@ -574,7 +590,8 @@ run_for_tokens!(
                 test_state: &mut TestState,
             ) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 common_escrow_tests::test_withdraw_does_not_work_before_withdrawal_start(test_state)
                     .await
             }
@@ -585,7 +602,8 @@ run_for_tokens!(
                 test_state: &mut TestState,
             ) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 common_escrow_tests::test_withdraw_does_not_work_after_cancellation_start(
                     test_state,
                 )
@@ -596,7 +614,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_withdraw_fails_with_incorrect_token(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (escrow, escrow_ata) = create_escrow(test_state).await;
 
                 test_state.token = <TestState as HasTokenVariant>::Token::deploy_spl_token(
@@ -622,7 +641,8 @@ run_for_tokens!(
                 test_state.test_arguments.src_timelocks =
                     init_timelocks(0, u32::MAX, 0, 0, 0, 0, 0, 0);
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (escrow, escrow_ata) = create_escrow(test_state).await;
                 let transaction = SrcProgram::get_public_withdraw_tx(
                     test_state,
@@ -646,7 +666,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_public_withdraw_tokens_by_taker(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (escrow, escrow_ata) = create_escrow(test_state).await;
 
                 let transaction = SrcProgram::get_public_withdraw_tx(
@@ -719,7 +740,7 @@ run_for_tokens!(
             async fn test_public_withdraw_tokens_any_resolver(test_state: &mut TestState) {
                 create_order(test_state).await;
                 let withdrawer = Keypair::new();
-                prepare_resolvers(
+                prepare_resolvers_src(
                     test_state,
                     &[
                         test_state.taker_wallet.keypair.pubkey(),
@@ -810,7 +831,7 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_public_withdraw_fails_with_wrong_secret(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(
+                prepare_resolvers_src(
                     test_state,
                     &[
                         test_state.taker_wallet.keypair.pubkey(),
@@ -825,7 +846,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_public_withdraw_fails_with_wrong_taker_ata(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 common_escrow_tests::test_public_withdraw_fails_with_wrong_taker_ata(test_state)
                     .await
             }
@@ -839,7 +861,8 @@ run_for_tokens!(
                 create_order(test_state).await;
                 test_state.test_arguments.order_amount -= diff;
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 common_escrow_tests::test_public_withdraw_fails_with_wrong_escrow_ata(
                     test_state, new_amount,
                 )
@@ -852,7 +875,7 @@ run_for_tokens!(
                 test_state: &mut TestState,
             ) {
                 create_order(test_state).await;
-                prepare_resolvers(
+                prepare_resolvers_src(
                     test_state,
                     &[
                         test_state.taker_wallet.keypair.pubkey(),
@@ -872,7 +895,7 @@ run_for_tokens!(
                 test_state: &mut TestState,
             ) {
                 create_order(test_state).await;
-                prepare_resolvers(
+                prepare_resolvers_src(
                     test_state,
                     &[
                         test_state.taker_wallet.keypair.pubkey(),
@@ -890,7 +913,8 @@ run_for_tokens!(
                 test_state: &mut TestState,
             ) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (escrow, escrow_ata) = create_escrow(test_state).await;
 
                 let withdrawer = Keypair::new();
@@ -915,7 +939,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_public_withdraw_fails_with_incorrect_token(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (escrow, escrow_ata) = create_escrow(test_state).await;
 
                 test_state.token = <TestState as HasTokenVariant>::Token::deploy_spl_token(
@@ -943,7 +968,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_cancel(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (escrow, escrow_ata) = create_escrow(test_state).await;
                 common_escrow_tests::test_cancel(test_state, &escrow, &escrow_ata).await
             }
@@ -952,7 +978,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_cancel_with_excess_tokens(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 let (escrow, escrow_ata) = create_escrow(test_state).await;
                 let transaction = SrcProgram::get_cancel_tx(test_state, &escrow, &escrow_ata);
@@ -991,7 +1018,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_cannot_cancel_by_non_maker(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 common_escrow_tests::test_cannot_cancel_by_non_maker(test_state).await
             }
 
@@ -999,7 +1027,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_cannot_cancel_with_wrong_maker_ata(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 common_escrow_tests::test_cannot_cancel_with_wrong_maker_ata(test_state).await
             }
 
@@ -1007,7 +1036,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_cannot_cancel_with_wrong_escrow_ata(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (escrow, _) = create_escrow(test_state).await;
 
                 test_state.test_arguments.order_amount += 1;
@@ -1029,7 +1059,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_cannot_cancel_before_cancellation_start(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 common_escrow_tests::test_cannot_cancel_before_cancellation_start(test_state).await
             }
 
@@ -1037,7 +1068,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_cancel_fails_with_incorrect_token(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (escrow, escrow_ata) = create_escrow(test_state).await;
 
                 test_state.token = <TestState as HasTokenVariant>::Token::deploy_spl_token(
@@ -1063,7 +1095,8 @@ run_for_tokens!(
                 test_state.test_arguments.src_timelocks =
                     init_timelocks(0, 0, u32::MAX, 0, 0, 0, 0, 0);
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (escrow, escrow_ata) = create_escrow(test_state).await;
                 let transaction = SrcProgram::get_cancel_tx(test_state, &escrow, &escrow_ata);
 
@@ -1081,14 +1114,16 @@ run_for_tokens!(
             #[test_context(TestState)]
             #[tokio::test]
             async fn test_order_cancel(test_state: &mut TestState) {
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 helpers_src::test_order_cancel(test_state).await;
             }
 
             #[test_context(TestState)]
             #[tokio::test]
             async fn test_rescue_tokens_when_order_is_deleted(test_state: &mut TestState) {
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 helpers_src::test_rescue_tokens_when_order_is_deleted(test_state).await;
             }
 
@@ -1096,7 +1131,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_order_cancel_fails_with_incorrect_token(test_state: &mut TestState) {
                 let (order, order_ata) = create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 test_state.token = <TestState as HasTokenVariant>::Token::deploy_spl_token(
                     &mut test_state.context,
@@ -1152,7 +1188,8 @@ run_for_tokens!(
             async fn test_cancel_by_resolver_for_free_at_the_auction_start(
                 test_state: &mut TestState,
             ) {
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 helpers_src::test_cancel_by_resolver_for_free_at_the_auction_start(test_state)
                     .await;
             }
@@ -1161,7 +1198,8 @@ run_for_tokens!(
             #[test_context(TestState)]
             #[tokio::test]
             async fn test_cancel_by_resolver_with_zero_maker_amount(test_state: &mut TestState) {
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 let token_account_rent = get_min_rent_for_size(
                     &mut test_state.client,
@@ -1210,7 +1248,8 @@ run_for_tokens!(
                 test_state: &mut TestState,
             ) {
                 let (order, order_ata) = create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let transaction =
                     get_cancel_order_by_resolver_tx(test_state, &order, &order_ata, None);
 
@@ -1249,7 +1288,8 @@ run_for_tokens!(
             #[test_context(TestState)]
             #[tokio::test]
             async fn test_cancel_by_resolver_after_auction(test_state: &mut TestState) {
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 helpers_src::test_cancel_by_resolver_after_auction(test_state).await;
             }
 
@@ -1258,7 +1298,8 @@ run_for_tokens!(
             async fn test_cancel_by_resolver_reward_less_then_auction_calculated(
                 test_state: &mut TestState,
             ) {
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 helpers_src::test_cancel_by_resolver_reward_less_then_auction_calculated(
                     test_state,
                 )
@@ -1272,7 +1313,8 @@ run_for_tokens!(
             ) {
                 let (order, order_ata) = create_order(test_state).await;
 
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let transaction =
                     get_cancel_order_by_resolver_tx(test_state, &order, &order_ata, None);
 
@@ -1289,7 +1331,8 @@ run_for_tokens!(
                 test_state: &mut TestState,
             ) {
                 let (order, order_ata) = create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 test_state.token = <TestState as HasTokenVariant>::Token::deploy_spl_token(
                     &mut test_state.context,
@@ -1314,7 +1357,8 @@ run_for_tokens!(
             #[test_context(TestState)]
             #[tokio::test]
             async fn test_public_cancel_by_taker(test_state: &mut TestState) {
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 create_order(test_state).await;
                 let (escrow, escrow_ata) = create_escrow(test_state).await;
                 test_public_cancel_escrow(
@@ -1338,7 +1382,7 @@ run_for_tokens!(
                 )
                 .await;
 
-                prepare_resolvers(
+                prepare_resolvers_src(
                     test_state,
                     &[test_state.taker_wallet.keypair.pubkey(), canceller.pubkey()],
                 )
@@ -1355,7 +1399,7 @@ run_for_tokens!(
                 test_state: &mut TestState,
             ) {
                 create_order(test_state).await;
-                prepare_resolvers(
+                prepare_resolvers_src(
                     test_state,
                     &[
                         test_state.taker_wallet.keypair.pubkey(),
@@ -1391,7 +1435,8 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_public_cancel_fails_with_incorrect_token(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (escrow, escrow_ata) = create_escrow(test_state).await;
 
                 test_state.token = <TestState as HasTokenVariant>::Token::deploy_spl_token(
@@ -1418,7 +1463,8 @@ run_for_tokens!(
             #[test_context(TestState)]
             #[tokio::test]
             async fn test_rescue_all_tokens_from_order_and_close_ata(test_state: &mut TestState) {
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 helpers_src::test_rescue_all_tokens_from_order_and_close_ata(test_state).await
             }
 
@@ -1427,7 +1473,8 @@ run_for_tokens!(
             async fn test_rescue_part_of_tokens_from_order_and_not_close_ata(
                 test_state: &mut TestState,
             ) {
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 helpers_src::test_rescue_part_of_tokens_from_order_and_not_close_ata(test_state)
                     .await
             }
@@ -1439,7 +1486,8 @@ run_for_tokens!(
             ) {
                 type S = <TestState as HasTokenVariant>::Token;
 
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (order, _) = create_order(test_state).await;
 
                 let token_to_rescue = S::deploy_spl_token(&mut test_state.context).await.pubkey();
@@ -1499,7 +1547,8 @@ run_for_tokens!(
             ) {
                 type S = <TestState as HasTokenVariant>::Token;
 
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (order, _) = create_order(test_state).await;
 
                 let token_to_rescue = S::deploy_spl_token(&mut test_state.context).await.pubkey();
@@ -1552,7 +1601,8 @@ run_for_tokens!(
             async fn test_cannot_rescue_funds_with_wrong_hash_order(test_state: &mut TestState) {
                 type S = <TestState as HasTokenVariant>::Token;
 
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
                 let (order, _) = create_order(test_state).await;
 
                 let token_to_rescue = S::deploy_spl_token(&mut test_state.context).await.pubkey();
@@ -1608,7 +1658,8 @@ run_for_tokens!(
             ) {
                 type S = <TestState as HasTokenVariant>::Token;
 
-                prepare_resolvers(test_state, &[test_state.taker_wallet.keypair.pubkey()]).await;
+                prepare_resolvers_src(test_state, &[test_state.taker_wallet.keypair.pubkey()])
+                    .await;
 
                 let (order, order_ata) = create_order(test_state).await;
 
@@ -1648,7 +1699,7 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_rescue_all_tokens_and_close_ata(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(
+                prepare_resolvers_src(
                     test_state,
                     &[
                         test_state.taker_wallet.keypair.pubkey(),
@@ -1663,7 +1714,7 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_rescue_part_of_tokens_and_not_close_ata(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(
+                prepare_resolvers_src(
                     test_state,
                     &[
                         test_state.taker_wallet.keypair.pubkey(),
@@ -1678,7 +1729,7 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_rescue_tokens_when_escrow_is_deleted(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(
+                prepare_resolvers_src(
                     test_state,
                     &[
                         test_state.taker_wallet.keypair.pubkey(),
@@ -1693,7 +1744,7 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_cannot_rescue_funds_before_rescue_delay_pass(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(
+                prepare_resolvers_src(
                     test_state,
                     &[
                         test_state.taker_wallet.keypair.pubkey(),
@@ -1709,7 +1760,7 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_cannot_rescue_funds_by_non_recipient(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(
+                prepare_resolvers_src(
                     test_state,
                     &[
                         test_state.taker_wallet.keypair.pubkey(),
@@ -1724,7 +1775,7 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_cannot_rescue_funds_with_wrong_taker_ata(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(
+                prepare_resolvers_src(
                     test_state,
                     &[
                         test_state.taker_wallet.keypair.pubkey(),
@@ -1739,7 +1790,7 @@ run_for_tokens!(
             #[tokio::test]
             async fn test_cannot_rescue_funds_with_wrong_order_ata(test_state: &mut TestState) {
                 create_order(test_state).await;
-                prepare_resolvers(
+                prepare_resolvers_src(
                     test_state,
                     &[
                         test_state.taker_wallet.keypair.pubkey(),

--- a/programs/whitelist/src/lib.rs
+++ b/programs/whitelist/src/lib.rs
@@ -7,7 +7,6 @@ use error::WhitelistError;
 declare_id!("CShaLBTQn6xbwq9behWTZuDuYY7APeWvXchsHkTw3DcZ");
 
 pub const WHITELIST_STATE_SEED: &[u8] = b"whitelist_state";
-pub const RESOLVER_ACCESS_SEED: &[u8] = b"resolver_access";
 
 /// Program for managing whitelisted users for the Fusion Swap
 #[program]
@@ -75,7 +74,7 @@ pub struct Register<'info> {
         init,
         payer = authority,
         space = DISCRIMINATOR_BYTES + ResolverAccess::INIT_SPACE,
-        seeds = [RESOLVER_ACCESS_SEED, client_program.key().as_ref(), user.key().as_ref()],
+        seeds = [client_program.key().as_ref(), user.key().as_ref()],
         bump,
     )]
     pub resolver_access: Account<'info, ResolverAccess>,
@@ -100,7 +99,7 @@ pub struct Deregister<'info> {
     #[account(
         mut,
         close = authority,
-        seeds = [RESOLVER_ACCESS_SEED, client_program.key().as_ref(), user.key().as_ref()],
+        seeds = [client_program.key().as_ref(), user.key().as_ref()],
         bump = resolver_access.bump,
     )]
     pub resolver_access: Account<'info, ResolverAccess>,

--- a/programs/whitelist/src/lib.rs
+++ b/programs/whitelist/src/lib.rs
@@ -22,13 +22,13 @@ pub mod whitelist {
     }
 
     /// Registers a new user to the whitelist
-    pub fn register(ctx: Context<Register>, _user: Pubkey) -> Result<()> {
+    pub fn register(ctx: Context<Register>, _user: Pubkey, _client: Pubkey) -> Result<()> {
         ctx.accounts.resolver_access.bump = ctx.bumps.resolver_access;
         Ok(())
     }
 
     /// Removes a user from the whitelist
-    pub fn deregister(_ctx: Context<Deregister>, _user: Pubkey) -> Result<()> {
+    pub fn deregister(_ctx: Context<Deregister>, _user: Pubkey, _client: Pubkey) -> Result<()> {
         Ok(())
     }
 
@@ -58,7 +58,7 @@ pub struct Initialize<'info> {
 }
 
 #[derive(Accounts)]
-#[instruction(user: Pubkey)]
+#[instruction(user: Pubkey, client_program: Pubkey)]
 pub struct Register<'info> {
     #[account(mut)]
     pub authority: Signer<'info>,
@@ -75,7 +75,7 @@ pub struct Register<'info> {
         init,
         payer = authority,
         space = DISCRIMINATOR_BYTES + ResolverAccess::INIT_SPACE,
-        seeds = [RESOLVER_ACCESS_SEED, user.key().as_ref()],
+        seeds = [RESOLVER_ACCESS_SEED, client_program.key().as_ref(), user.key().as_ref()],
         bump,
     )]
     pub resolver_access: Account<'info, ResolverAccess>,
@@ -84,7 +84,7 @@ pub struct Register<'info> {
 }
 
 #[derive(Accounts)]
-#[instruction(user: Pubkey)]
+#[instruction(user: Pubkey, client_program: Pubkey)]
 pub struct Deregister<'info> {
     #[account(mut)]
     pub authority: Signer<'info>,
@@ -100,7 +100,7 @@ pub struct Deregister<'info> {
     #[account(
         mut,
         close = authority,
-        seeds = [RESOLVER_ACCESS_SEED, user.key().as_ref()],
+        seeds = [RESOLVER_ACCESS_SEED, client_program.key().as_ref(), user.key().as_ref()],
         bump = resolver_access.bump,
     )]
     pub resolver_access: Account<'info, ResolverAccess>,

--- a/programs/whitelist/tests/helpers.rs
+++ b/programs/whitelist/tests/helpers.rs
@@ -115,7 +115,8 @@ pub fn register_deregister_data(
     instruction_data: Vec<u8>,
 ) -> (Pubkey, Transaction) {
     let (whitelist_state, program_id) = get_whitelist_state_address();
-    let (whitelist_access, _) = get_whitelist_access_address(&test_state.whitelisted_kp.pubkey());
+    let (whitelist_access, _) =
+        get_whitelist_access_address(&whitelist::id(), &test_state.whitelisted_kp.pubkey());
 
     let instruction: Instruction = Instruction {
         program_id,
@@ -136,9 +137,10 @@ pub fn register_deregister_data(
     (whitelist_access, transaction)
 }
 
-pub async fn register(test_state: &TestState) -> Pubkey {
+pub async fn register(test_state: &TestState, client_program: Pubkey) -> Pubkey {
     let instruction_data = InstructionData::data(&whitelist::instruction::Register {
         _user: test_state.whitelisted_kp.pubkey(),
+        _client: client_program,
     });
 
     let (whitelist_access, tx) = register_deregister_data(test_state, instruction_data);
@@ -150,9 +152,10 @@ pub async fn register(test_state: &TestState) -> Pubkey {
     whitelist_access
 }
 
-pub async fn deregister(test_state: &TestState) -> Pubkey {
+pub async fn deregister(test_state: &TestState, client_program: Pubkey) -> Pubkey {
     let instruction_data = InstructionData::data(&whitelist::instruction::Deregister {
         _user: test_state.whitelisted_kp.pubkey(),
+        _client: client_program,
     });
 
     let (whitelist_access, tx) = register_deregister_data(test_state, instruction_data);


### PR DESCRIPTION
Generalize whitelist program to work with any program. This is done by including the client programs contract address in the seeds for access address, along with the pk of the whitelisted user.